### PR TITLE
Add a log filter

### DIFF
--- a/log/filtered/filtered.go
+++ b/log/filtered/filtered.go
@@ -1,0 +1,170 @@
+package filtered
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/TheThingsNetwork/go-utils/log"
+)
+
+// A Filter is something that can filter a field value
+type Filter interface {
+	Filter(string, interface{}) interface{}
+}
+
+// A FilterFunc is a function that implements the Filter interface
+type FilterFunc func(string, interface{}) interface{}
+
+// Filter implements the Filter interface for FilterFuncs
+func (fn FilterFunc) Filter(k string, v interface{}) interface{} {
+	return fn(k, v)
+}
+
+// Filtered is a logger that filters the fields it receives
+type Filtered struct {
+	log.Interface
+	filters []Filter
+}
+
+// Wrap wraps an existing logger, filtering the fields as it goes along
+// using the provided filters
+func Wrap(logger log.Interface, filters ...Filter) *Filtered {
+	return &Filtered{
+		Interface: logger,
+		filters:   filters,
+	}
+}
+
+// WithFilter creates a new Filtered that will use the extra filters
+func (f *Filtered) WithFilters(filters ...Filter) *Filtered {
+	return &Filtered{
+		Interface: f.Interface,
+		filters:   append(f.filters, filters...),
+	}
+}
+
+// WithField filters the field and passes it on to the wrapped loggers WithField
+func (f *Filtered) WithField(k string, v interface{}) log.Interface {
+	val := v
+
+	// apply the filters
+	for _, filter := range f.filters {
+		val = filter.Filter(k, val)
+	}
+
+	f.Interface = f.Interface.WithField(k, val)
+	return f
+}
+
+// WithFields filters the fields and passes them on to the wrapped loggers WithFields
+func (f *Filtered) WithFields(fields log.Fields) log.Interface {
+	res := make(map[string]interface{}, len(fields))
+
+	for k, v := range fields {
+		val := v
+
+		// apply the filters
+		for _, filter := range f.filters {
+			val = filter.Filter(k, val)
+		}
+
+		res[k] = val
+	}
+
+	f.Interface = f.Interface.WithFields(res)
+	return f
+}
+
+var (
+	defaultElided    = "<elided>"
+	defaultSensitive = []string{
+		"token",
+		"access_token",
+		"refresh_token",
+		"key",
+		"password",
+		"code",
+	}
+
+	// DefaultSensitiveFilter is a Filter that filters most sensitive data and
+	// replaces it with `<elided>`. These fields are filtered:
+	// token, access_token, refresh_token, key, password, code
+	DefaultSensitiveFilter = FilterSensitive(defaultSensitive, defaultElided)
+
+	// QueryFilter filters maps at the fields with the name 'query', using the same rules as
+	// DefaultSensitiveFilter
+	DefaultQueryFilter = RestrictFilter("query", LowerCaseFilter(MapFilter(SliceFilter(DefaultSensitiveFilter))))
+)
+
+// FilterSensitive creates a Filter that filters most sensitive data like passwords,
+// keys, access_tokens, etc. and replaces them with the elided value
+func FilterSensitive(sensitive []string, elided interface{}) Filter {
+	return FilterFunc(func(key string, v interface{}) interface{} {
+		lower := strings.ToLower(key)
+		for _, s := range sensitive {
+			if lower == s {
+				return elided
+			}
+		}
+
+		return v
+	})
+}
+
+// SliceFilter lifts the filter to also work on slices. It loses the
+// type information of the slice elements
+func SliceFilter(filter Filter) Filter {
+	return FilterFunc(func(k string, v interface{}) interface{} {
+		r := reflect.ValueOf(v)
+		if r.Kind() == reflect.Slice {
+			res := make([]interface{}, 0, r.Len())
+			for i := 0; i < r.Len(); i++ {
+				el := r.Index(i).Interface()
+				res = append(res, filter.Filter(k, el))
+			}
+
+			return res
+		}
+
+		return filter.Filter(k, v)
+	})
+}
+
+// MapFilter lifts the filter to also work on maps. It loses the type
+// information of the map fields
+func MapFilter(filter Filter) Filter {
+	return FilterFunc(func(k string, v interface{}) interface{} {
+		r := reflect.ValueOf(v)
+		if r.Kind() == reflect.Map {
+			// res will be the filtered map
+			res := make(map[string]interface{}, r.Len())
+			for _, key := range r.MapKeys() {
+				str := key.String()
+				val := r.MapIndex(key).Interface()
+				res[str] = filter.Filter(str, val)
+			}
+
+			return res
+		}
+
+		return v
+	})
+}
+
+// RestrictFilter restricts the filter to only work on a certain field
+func RestrictFilter(fieldName string, filter Filter) Filter {
+	return FilterFunc(func(k string, v interface{}) interface{} {
+		if fieldName == k {
+			return filter.Filter(k, v)
+		}
+
+		return v
+	})
+}
+
+// LowerCaseFilter creates a filter that only get passed lowercase field names
+func LowerCaseFilter(filter Filter) Filter {
+	return FilterFunc(func(k string, v interface{}) interface{} {
+		return filter.Filter(strings.ToLower(k), v)
+	})
+}

--- a/log/filtered/filtered_test.go
+++ b/log/filtered/filtered_test.go
@@ -1,0 +1,156 @@
+package filtered
+
+import (
+	"testing"
+
+	"github.com/TheThingsNetwork/go-utils/log"
+	. "github.com/smartystreets/assertions"
+)
+
+// noopLogger just does nothing
+type noopLogger struct{}
+
+func (l noopLogger) Debug(msg string)                            {}
+func (l noopLogger) Info(msg string)                             {}
+func (l noopLogger) Warn(msg string)                             {}
+func (l noopLogger) Error(msg string)                            {}
+func (l noopLogger) Fatal(msg string)                            {}
+func (l noopLogger) Debugf(msg string, v ...interface{})         {}
+func (l noopLogger) Infof(msg string, v ...interface{})          {}
+func (l noopLogger) Warnf(msg string, v ...interface{})          {}
+func (l noopLogger) Errorf(msg string, v ...interface{})         {}
+func (l noopLogger) Fatalf(msg string, v ...interface{})         {}
+func (l noopLogger) WithField(string, interface{}) log.Interface { return l }
+func (l noopLogger) WithFields(log.Fields) log.Interface         { return l }
+func (l noopLogger) WithError(error) log.Interface               { return l }
+
+// FieldsLogger is a logger that stores which fields it has been passed
+type FieldsLogger struct {
+	log.Interface
+	Fields map[string]interface{}
+}
+
+// WithField saves the fields and calls the wrapped loggers WithField
+func (f *FieldsLogger) WithField(k string, v interface{}) log.Interface {
+	flds := make(map[string]interface{}, len(f.Fields)+1)
+	for k, v := range f.Fields {
+		flds[k] = v
+	}
+
+	// add the new field
+	flds[k] = v
+
+	return &FieldsLogger{
+		Interface: f.Interface.WithField(k, v),
+		Fields:    flds,
+	}
+}
+
+// WithFields saves the fields and calls the wrapped loggers WithFields
+func (f *FieldsLogger) WithFields(fields log.Fields) log.Interface {
+	flds := make(map[string]interface{}, len(f.Fields)+1)
+	for k, v := range f.Fields {
+		flds[k] = v
+	}
+
+	// add the new field
+	for k, v := range fields {
+		flds[k] = v
+	}
+
+	return &FieldsLogger{
+		Interface: f.Interface.WithFields(fields),
+		Fields:    flds,
+	}
+}
+
+func TestFieldsLogger(t *testing.T) {
+	a := New(t)
+
+	logger := &FieldsLogger{
+		Interface: &noopLogger{},
+	}
+
+	logger = logger.WithField("foo", 42).(*FieldsLogger)
+
+	a.So(logger.Fields, ShouldContainKey, "foo")
+	a.So(logger.Fields["foo"], ShouldEqual, 42)
+
+	logger = logger.WithFields(log.Fields{
+		"bar": "lol",
+		"baz": true,
+	}).(*FieldsLogger)
+
+	a.So(logger.Fields, ShouldContainKey, "foo")
+	a.So(logger.Fields["foo"], ShouldEqual, 42)
+
+	a.So(logger.Fields, ShouldContainKey, "bar")
+	a.So(logger.Fields["bar"], ShouldEqual, "lol")
+
+	a.So(logger.Fields, ShouldContainKey, "baz")
+	a.So(logger.Fields["baz"], ShouldEqual, true)
+}
+
+func TestFilterSensitive(t *testing.T) {
+	a := New(t)
+
+	wrapped := Wrap(&FieldsLogger{
+		Interface: &noopLogger{},
+	}, DefaultSensitiveFilter)
+
+	// should elide passwords
+	{
+		wrapped.WithField("password", "secret")
+
+		fields := wrapped.Interface.(*FieldsLogger).Fields
+		a.So(fields, ShouldContainKey, "password")
+		a.So(fields["password"], ShouldEqual, defaultElided)
+	}
+
+	// should not elide other stuff
+	{
+		wrapped.WithField("foo", "bar")
+		fields := wrapped.Interface.(*FieldsLogger).Fields
+		a.So(fields, ShouldContainKey, "foo")
+		a.So(fields["foo"], ShouldEqual, "bar")
+	}
+
+	// should work the same with more fields
+	{
+		wrapped.WithFields(log.Fields{
+			"bar":   "baz",
+			"token": "secret",
+		})
+		fields := wrapped.Interface.(*FieldsLogger).Fields
+		a.So(fields, ShouldContainKey, "bar")
+		a.So(fields["bar"], ShouldEqual, "baz")
+
+		a.So(fields, ShouldContainKey, "token")
+		a.So(fields["token"], ShouldEqual, defaultElided)
+	}
+}
+
+func TestFilterQuery(t *testing.T) {
+	a := New(t)
+
+	wrapped := Wrap(&FieldsLogger{
+		Interface: &noopLogger{},
+	}, DefaultQueryFilter)
+
+	wrapped.WithField("query", map[string][]string{
+		"password": []string{"secret"},
+		"foo":      []string{"bar"},
+	})
+
+	fields := wrapped.Interface.(*FieldsLogger).Fields
+
+	a.So(fields, ShouldContainKey, "query")
+
+	query := fields["query"].(map[string]interface{})
+
+	a.So(query, ShouldContainKey, "password")
+	a.So(query["password"], ShouldResemble, []interface{}{defaultElided})
+
+	a.So(query, ShouldContainKey, "foo")
+	a.So(query["foo"], ShouldResemble, []interface{}{"bar"})
+}


### PR DESCRIPTION
Add a logger implements `log.Interface` by wrapping another logger, filtering the fields as it goes along.

Also implements some useful filters and helpers to create filters.