### PR TITLE
Added not supproted error type

### DIFF
--- a/errors/types.go
+++ b/errors/types.go
@@ -18,11 +18,8 @@ const (
 	// AlreadyExists means that the entity already exists
 	AlreadyExists Type = "already exists"
 
-	// NotImplemented means action is known but not implemented yet
+	// NotImplemented means action is known but not implemented
 	NotImplemented Type = "not implemented"
-
-	// NotSupported means action is known but will not be implemented
-	NotSupported Type = "not supported"
 
 	// Unauthenticated means the client has made no authentication, while it
 	// should have

--- a/errors/types.go
+++ b/errors/types.go
@@ -21,6 +21,9 @@ const (
 	// NotImplemented means action is known but not implemented yet
 	NotImplemented Type = "not implemented"
 
+	// NotSupported means action is known but will not be implemented
+	NotSupported Type = "not supported"
+
 	// Unauthenticated means the client has made no authentication, while it
 	// should have
 	Unauthenticated Type = "unauthenticated"


### PR DESCRIPTION
According to the comments, `NotImplemented` means that something is not implemented yet but will be implemented in the future. It could be useful however to have a `NotSupported` error to translate that an action is known but will not be implemented.