### PR TITLE
encoding: fix pointer type encoding, decoding, tests

### DIFF
--- a/encoding/decode.go
+++ b/encoding/decode.go
@@ -130,7 +130,7 @@ func FromStringStringMap(tagName string, base interface{}, input map[string]stri
 			fieldKind = fieldType.Kind()
 		}
 
-		var fieldVal interface{}
+		var iface interface{}
 
 		if fieldKind == reflect.Struct {
 			if opts.Has("include") {
@@ -160,20 +160,22 @@ func FromStringStringMap(tagName string, base interface{}, input map[string]stri
 
 		switch fieldKind {
 		case reflect.Array, reflect.Interface, reflect.Slice, reflect.Map:
-			fieldVal, err = unmarshalToType(fieldType, inputStr)
+			iface, err = unmarshalToType(fieldType, inputStr)
 			if err != nil {
 				return nil, err
 			}
 		default:
-			fieldVal = decodeToType(fieldKind, inputStr)
+			iface = decodeToType(fieldKind, inputStr)
 		}
+
+		fieldVal := reflect.ValueOf(iface).Convert(fieldType)
 
 		if isPointerField {
 			fieldValPtr := reflect.New(fieldType)
-			fieldValPtr.Elem().Set(reflect.ValueOf(fieldVal))
+			fieldValPtr.Elem().Set(fieldVal)
 			val.Field(i).Set(fieldValPtr)
 		} else {
-			val.Field(i).Set(reflect.ValueOf(fieldVal))
+			val.Field(i).Set(fieldVal)
 		}
 	}
 

--- a/encoding/decode.go
+++ b/encoding/decode.go
@@ -136,6 +136,10 @@ func FromStringStringMap(tagName string, base interface{}, input map[string]stri
 					}
 				}
 
+				if len(subInput) == 0 {
+					continue
+				}
+
 				subOutput, err := FromStringStringMap(tagName, val.Field(i).Interface(), subInput)
 				if err != nil {
 					return nil, err

--- a/encoding/decode.go
+++ b/encoding/decode.go
@@ -116,11 +116,16 @@ func FromStringStringMap(tagName string, base interface{}, input map[string]stri
 			continue
 		}
 
+		inputStr, fieldInInput := input[fieldName]
+
 		fieldType := field.Type
 		fieldKind := field.Type.Kind()
 
 		isPointerField := fieldKind == reflect.Ptr
 		if isPointerField {
+			if inputStr == "null" {
+				continue
+			}
 			fieldType = fieldType.Elem()
 			fieldKind = fieldType.Kind()
 		}
@@ -149,19 +154,18 @@ func FromStringStringMap(tagName string, base interface{}, input map[string]stri
 			continue
 		}
 
-		str, ok := input[fieldName]
-		if !ok || str == "" || isPointerField && str == "null" {
+		if !fieldInInput || inputStr == "" {
 			continue
 		}
 
 		switch fieldKind {
 		case reflect.Array, reflect.Interface, reflect.Slice, reflect.Map:
-			fieldVal, err = unmarshalToType(fieldType, str)
+			fieldVal, err = unmarshalToType(fieldType, inputStr)
 			if err != nil {
 				return nil, err
 			}
 		default:
-			fieldVal = decodeToType(fieldKind, str)
+			fieldVal = decodeToType(fieldKind, inputStr)
 		}
 
 		if isPointerField {

--- a/encoding/decode.go
+++ b/encoding/decode.go
@@ -107,7 +107,7 @@ func FromStringStringMap(tagName string, base interface{}, input map[string]stri
 	for i := 0; i < valType.NumField(); i++ {
 		field := valType.Field(i)
 
-		if field.Anonymous {
+		if field.PkgPath != "" {
 			continue
 		}
 
@@ -141,8 +141,8 @@ func FromStringStringMap(tagName string, base interface{}, input map[string]stri
 					return nil, err
 				}
 				val.Field(i).Set(reflect.ValueOf(subOutput))
-				continue
 			}
+			continue
 		}
 
 		str, ok := input[fieldName]

--- a/encoding/encode.go
+++ b/encoding/encode.go
@@ -81,7 +81,14 @@ func ToStringStringMap(tagName string, input interface{}, properties ...string) 
 			}
 		}
 
-		if opts.Has("include") && field.Kind() == reflect.Struct {
+		kind := field.Kind()
+		if kind == reflect.Ptr {
+			elem := reflect.ValueOf(val).Elem()
+			kind = elem.Kind()
+			val = elem.Interface()
+		}
+
+		if opts.Has("include") && kind == reflect.Struct {
 			var newProperties []string
 			for _, prop := range properties {
 				if strings.HasPrefix(prop, fieldName+".") {
@@ -125,7 +132,7 @@ func ToStringStringMap(tagName string, input interface{}, properties ...string) 
 			}
 		}
 
-		if field.Kind() == reflect.String {
+		if kind == reflect.String {
 			vmap[fieldName] = fmt.Sprint(val)
 			continue
 		}
@@ -180,7 +187,15 @@ func ToStringInterfaceMap(tagName string, input interface{}, properties ...strin
 			}
 		}
 
-		if opts.Has("include") && field.Kind() == reflect.Struct {
+		kind := field.Kind()
+
+		if field.Kind() == reflect.Ptr {
+			elem := reflect.ValueOf(val).Elem()
+			kind = elem.Kind()
+			val = elem.Interface()
+		}
+
+		if opts.Has("include") && kind == reflect.Struct {
 			var newProperties []string
 			for _, prop := range properties {
 				if strings.HasPrefix(prop, fieldName+".") {

--- a/encoding/encoding_test.go
+++ b/encoding/encoding_test.go
@@ -99,7 +99,7 @@ const (
 	StringStringMap = "stringStringMap"
 
 	InclStruct         = "inclStruct"
-	InclStructEmpty    = "inclStructPtrEmpty"
+	InclStructEmpty    = "inclStructEmpty"
 	InclStructPtr      = "inclStructPtr"
 	InclStructPtrEmpty = "inclStructPtrEmpty"
 

--- a/encoding/encoding_test.go
+++ b/encoding/encoding_test.go
@@ -107,8 +107,8 @@ const (
 
 	SubInclStruct = "subInclStruct"
 
-	Struct    = "struct"
-	Interface = "interface"
+	EmbStructTag    = "embStruct"
+	EmbInterfaceTag = "embInterface"
 )
 
 type inclStruct struct {
@@ -167,8 +167,8 @@ type testStruct struct {
 
 	StringStringMap map[string]string `test:"stringStringMap"`
 
-	EmbStruct    `test:"struct,include"`
-	EmbInterface `test:"interface,include"`
+	EmbStruct    `test:"embStruct,include"`
+	EmbInterface `test:"embInterface,include"`
 
 	InclStruct         inclStruct  `test:"inclStruct,include"`
 	InclStructEmpty    inclStruct  `test:"inclStructEmpty,include,omitempty"`
@@ -232,7 +232,7 @@ func TestFromStringStringMap(t *testing.T) {
 
 				StringStringMap: stringStringMapVarString,
 
-				Struct + "." + Int: strconv.Itoa(intVar),
+				EmbStructTag + "." + Int: strconv.Itoa(intVar),
 
 				InclStruct + "." + Int:                       strconv.Itoa(intVar),
 				InclStruct + "." + SubInclStruct + "." + Int: strconv.Itoa(intVar),
@@ -324,7 +324,7 @@ func TestFromStringStringMap(t *testing.T) {
 
 			a.So(v.StringStringMap, s.ShouldResemble, stringStringMapVar)
 
-			a.So(v.EmbStruct.Int, s.ShouldEqual, func() int { val, _ := strconv.ParseInt(m[Struct+"."+Int], 10, 0); return int(val) }())
+			a.So(v.EmbStruct.Int, s.ShouldEqual, func() int { val, _ := strconv.ParseInt(m[EmbStructTag+"."+Int], 10, 0); return int(val) }())
 
 			a.So(v.InclStruct.Int, s.ShouldEqual, func() int { val, _ := strconv.ParseInt(m[InclStruct+"."+Int], 10, 0); return int(val) }())
 			a.So(v.InclStruct.SubInclStruct.Int, s.ShouldEqual, func() int {
@@ -452,7 +452,7 @@ func TestToStringStringMap(t *testing.T) {
 
 			a.So(enc[StringStringMap], s.ShouldEqual, marshalToString(v.StringStringMap))
 
-			a.So(enc[Struct+".int"], s.ShouldEqual, strconv.FormatInt(int64(v.EmbStruct.Int), 10))
+			a.So(enc[EmbStructTag+".int"], s.ShouldEqual, strconv.FormatInt(int64(v.EmbStruct.Int), 10))
 
 			a.So(enc[InclStruct+".int"], s.ShouldEqual, strconv.FormatInt(int64(v.InclStruct.Int), 10))
 			a.So(enc[InclStruct+"."+SubInclStruct+".int"], s.ShouldEqual, strconv.FormatInt(int64(v.InclStruct.SubInclStruct.Int), 10))
@@ -528,7 +528,7 @@ func TestToStringInterfaceMap(t *testing.T) {
 
 			a.So(enc[StringStringMap], s.ShouldResemble, v.StringStringMap)
 
-			a.So(enc[Struct+".int"], s.ShouldEqual, v.EmbStruct.Int)
+			a.So(enc[EmbStructTag+".int"], s.ShouldEqual, v.EmbStruct.Int)
 
 			a.So(enc[InclStruct+".int"], s.ShouldEqual, v.InclStruct.Int)
 			a.So(enc[InclStruct+"."+SubInclStruct+".int"], s.ShouldEqual, v.InclStruct.SubInclStruct.Int)

--- a/encoding/encoding_test.go
+++ b/encoding/encoding_test.go
@@ -100,6 +100,7 @@ const (
 
 	InclStruct    = "inclStruct"
 	SubInclStruct = "subInclStruct"
+	InclStructPtr = "inclStructPtr"
 
 	Struct    = "struct"
 	Interface = "interface"
@@ -163,7 +164,8 @@ type testStruct struct {
 
 	StringStringMap map[string]string `test:"stringStringMap"`
 
-	InclStruct inclStruct `test:"inclStruct,include"`
+	InclStruct    inclStruct  `test:"inclStruct,include"`
+	InclStructPtr *inclStruct `test:"inclStructPtr,include"`
 }
 
 func TestFromStringStringMap(t *testing.T) {
@@ -220,9 +222,11 @@ func TestFromStringStringMap(t *testing.T) {
 
 				StringStringMap: stringStringMapVarString,
 
-				InclStruct + "." + Int: strconv.Itoa(intVar),
-
+				InclStruct + "." + Int:                       strconv.Itoa(intVar),
 				InclStruct + "." + SubInclStruct + "." + Int: strconv.Itoa(intVar),
+
+				InclStructPtr + "." + Int:                       strconv.Itoa(intVar),
+				InclStructPtr + "." + SubInclStruct + "." + Int: strconv.Itoa(intVar),
 			}
 
 			ret, err := FromStringStringMap(testTag, arg, m)
@@ -306,11 +310,18 @@ func TestFromStringStringMap(t *testing.T) {
 			a.So(v.StringStringMap, s.ShouldResemble, stringStringMapVar)
 
 			a.So(v.InclStruct.Int, s.ShouldEqual, func() int { val, _ := strconv.ParseInt(m[InclStruct+"."+Int], 10, 0); return int(val) }())
-
 			a.So(v.InclStruct.SubInclStruct.Int, s.ShouldEqual, func() int {
 				val, _ := strconv.ParseInt(m[InclStruct+"."+SubInclStruct+"."+Int], 10, 0)
 				return int(val)
 			}())
+
+			if a.So(v.InclStructPtr, s.ShouldNotBeNil) {
+				a.So(v.InclStructPtr.Int, s.ShouldEqual, func() int { val, _ := strconv.ParseInt(m[InclStructPtr+"."+Int], 10, 0); return int(val) }())
+				a.So(v.InclStructPtr.SubInclStruct.Int, s.ShouldEqual, func() int {
+					val, _ := strconv.ParseInt(m[InclStructPtr+"."+SubInclStruct+"."+Int], 10, 0)
+					return int(val)
+				}())
+			}
 		})
 	}
 }
@@ -356,7 +367,8 @@ var testStructVar = testStruct{
 
 	StringStringMap: stringStringMapVar,
 
-	InclStruct: inclStructVar,
+	InclStruct:    inclStructVar,
+	InclStructPtr: &inclStructVar,
 }
 
 func TestToStringStringMap(t *testing.T) {
@@ -419,6 +431,9 @@ func TestToStringStringMap(t *testing.T) {
 
 			a.So(enc[InclStruct+".int"], s.ShouldEqual, strconv.FormatInt(int64(v.InclStruct.Int), 10))
 			a.So(enc[InclStruct+"."+SubInclStruct+".int"], s.ShouldEqual, strconv.FormatInt(int64(v.InclStruct.SubInclStruct.Int), 10))
+
+			a.So(enc[InclStructPtr+".int"], s.ShouldEqual, strconv.FormatInt(int64(v.InclStructPtr.Int), 10))
+			a.So(enc[InclStructPtr+"."+SubInclStruct+".int"], s.ShouldEqual, strconv.FormatInt(int64(v.InclStructPtr.SubInclStruct.Int), 10))
 		})
 	}
 }
@@ -456,20 +471,20 @@ func TestToStringInterfaceMap(t *testing.T) {
 			a.So(enc[Bool], s.ShouldEqual, v.Bool)
 			a.So(enc[String], s.ShouldEqual, v.String)
 
-			a.So(enc[IntPtr], s.ShouldEqual, v.IntPtr)
-			a.So(enc[Int8Ptr], s.ShouldEqual, v.Int8Ptr)
-			a.So(enc[Int16Ptr], s.ShouldEqual, v.Int16Ptr)
-			a.So(enc[Int32Ptr], s.ShouldEqual, v.Int32Ptr)
-			a.So(enc[Int64Ptr], s.ShouldEqual, v.Int64Ptr)
-			a.So(enc[UintPtr], s.ShouldEqual, v.UintPtr)
-			a.So(enc[Uint8Ptr], s.ShouldEqual, v.Uint8Ptr)
-			a.So(enc[Uint16Ptr], s.ShouldEqual, v.Uint16Ptr)
-			a.So(enc[Uint32Ptr], s.ShouldEqual, v.Uint32Ptr)
-			a.So(enc[Uint64Ptr], s.ShouldEqual, v.Uint64Ptr)
-			a.So(enc[Float32Ptr], s.ShouldEqual, v.Float32Ptr)
-			a.So(enc[Float64Ptr], s.ShouldEqual, v.Float64Ptr)
-			a.So(enc[BoolPtr], s.ShouldEqual, v.BoolPtr)
-			a.So(enc[StringPtr], s.ShouldEqual, v.StringPtr)
+			a.So(enc[IntPtr], s.ShouldEqual, *v.IntPtr)
+			a.So(enc[Int8Ptr], s.ShouldEqual, *v.Int8Ptr)
+			a.So(enc[Int16Ptr], s.ShouldEqual, *v.Int16Ptr)
+			a.So(enc[Int32Ptr], s.ShouldEqual, *v.Int32Ptr)
+			a.So(enc[Int64Ptr], s.ShouldEqual, *v.Int64Ptr)
+			a.So(enc[UintPtr], s.ShouldEqual, *v.UintPtr)
+			a.So(enc[Uint8Ptr], s.ShouldEqual, *v.Uint8Ptr)
+			a.So(enc[Uint16Ptr], s.ShouldEqual, *v.Uint16Ptr)
+			a.So(enc[Uint32Ptr], s.ShouldEqual, *v.Uint32Ptr)
+			a.So(enc[Uint64Ptr], s.ShouldEqual, *v.Uint64Ptr)
+			a.So(enc[Float32Ptr], s.ShouldEqual, *v.Float32Ptr)
+			a.So(enc[Float64Ptr], s.ShouldEqual, *v.Float64Ptr)
+			a.So(enc[BoolPtr], s.ShouldEqual, *v.BoolPtr)
+			a.So(enc[StringPtr], s.ShouldEqual, *v.StringPtr)
 
 			a.So(enc[IntSlice], s.ShouldResemble, v.IntSlice)
 			a.So(enc[BoolSlice], s.ShouldResemble, v.BoolSlice)
@@ -483,6 +498,9 @@ func TestToStringInterfaceMap(t *testing.T) {
 
 			a.So(enc[InclStruct+".int"], s.ShouldEqual, v.InclStruct.Int)
 			a.So(enc[InclStruct+"."+SubInclStruct+".int"], s.ShouldEqual, v.InclStruct.SubInclStruct.Int)
+
+			a.So(enc[InclStructPtr+".int"], s.ShouldEqual, v.InclStructPtr.Int)
+			a.So(enc[InclStructPtr+"."+SubInclStruct+".int"], s.ShouldEqual, v.InclStructPtr.SubInclStruct.Int)
 		})
 	}
 }

--- a/encoding/encoding_test.go
+++ b/encoding/encoding_test.go
@@ -98,9 +98,14 @@ const (
 
 	StringStringMap = "stringStringMap"
 
-	InclStruct    = "inclStruct"
+	InclStruct         = "inclStruct"
+	InclStructEmpty    = "inclStructPtrEmpty"
+	InclStructPtr      = "inclStructPtr"
+	InclStructPtrEmpty = "inclStructPtrEmpty"
+
+	InclStructEmb = "inclStructEmb"
+
 	SubInclStruct = "subInclStruct"
-	InclStructPtr = "inclStructPtr"
 
 	Struct    = "struct"
 	Interface = "interface"
@@ -115,12 +120,13 @@ type subInclStruct struct {
 	Int int `test:"int"`
 }
 
-type embStruct struct{}
-type embInterface interface{}
+type EmbStruct struct {
+	Int int `test:"int"`
+}
+type EmbInterface interface {
+	Test()
+}
 type testStruct struct {
-	embStruct
-	embInterface
-
 	Int     int     `test:"int"`
 	Int8    int8    `test:"int8"`
 	Int16   int16   `test:"int16"`
@@ -151,9 +157,6 @@ type testStruct struct {
 	StringPtr  *string  `test:"stringPtr"`
 	BoolPtr    *bool    `test:"boolPtr"`
 
-	Struct    struct{}    `test:"struct"`
-	Interface interface{} `test:"interface"`
-
 	IntSlice    []int    `test:"intSlice"`
 	BoolSlice   []bool   `test:"boolSlice"`
 	StringSlice []string `test:"stringSlice"`
@@ -164,8 +167,15 @@ type testStruct struct {
 
 	StringStringMap map[string]string `test:"stringStringMap"`
 
-	InclStruct    inclStruct  `test:"inclStruct,include"`
-	InclStructPtr *inclStruct `test:"inclStructPtr,include"`
+	EmbStruct    `test:"struct,include"`
+	EmbInterface `test:"interface,include"`
+
+	InclStruct         inclStruct  `test:"inclStruct,include"`
+	InclStructEmpty    inclStruct  `test:"inclStructEmpty,include,omitempty"`
+	InclStructPtr      *inclStruct `test:"inclStructPtr,include"`
+	InclStructPtrEmpty *inclStruct `test:"inclStructPtrEmpty,include,omitempty"`
+
+	inclStruct `test:"inclStructEmb,include"`
 }
 
 func TestFromStringStringMap(t *testing.T) {
@@ -222,11 +232,16 @@ func TestFromStringStringMap(t *testing.T) {
 
 				StringStringMap: stringStringMapVarString,
 
+				Struct + "." + Int: strconv.Itoa(intVar),
+
 				InclStruct + "." + Int:                       strconv.Itoa(intVar),
 				InclStruct + "." + SubInclStruct + "." + Int: strconv.Itoa(intVar),
 
 				InclStructPtr + "." + Int:                       strconv.Itoa(intVar),
 				InclStructPtr + "." + SubInclStruct + "." + Int: strconv.Itoa(intVar),
+
+				InclStructEmb + "." + Int:                       strconv.Itoa(intVar),
+				InclStructEmb + "." + SubInclStruct + "." + Int: strconv.Itoa(intVar),
 			}
 
 			ret, err := FromStringStringMap(testTag, arg, m)
@@ -309,6 +324,8 @@ func TestFromStringStringMap(t *testing.T) {
 
 			a.So(v.StringStringMap, s.ShouldResemble, stringStringMapVar)
 
+			a.So(v.EmbStruct.Int, s.ShouldEqual, func() int { val, _ := strconv.ParseInt(m[Struct+"."+Int], 10, 0); return int(val) }())
+
 			a.So(v.InclStruct.Int, s.ShouldEqual, func() int { val, _ := strconv.ParseInt(m[InclStruct+"."+Int], 10, 0); return int(val) }())
 			a.So(v.InclStruct.SubInclStruct.Int, s.ShouldEqual, func() int {
 				val, _ := strconv.ParseInt(m[InclStruct+"."+SubInclStruct+"."+Int], 10, 0)
@@ -322,6 +339,10 @@ func TestFromStringStringMap(t *testing.T) {
 					return int(val)
 				}())
 			}
+
+			a.So(v.inclStruct, s.ShouldBeZeroValue)
+			a.So(v.InclStructEmpty, s.ShouldBeZeroValue)
+			a.So(v.InclStructPtrEmpty, s.ShouldBeNil)
 		})
 	}
 }
@@ -369,6 +390,8 @@ var testStructVar = testStruct{
 
 	InclStruct:    inclStructVar,
 	InclStructPtr: &inclStructVar,
+
+	inclStruct: inclStructVar,
 }
 
 func TestToStringStringMap(t *testing.T) {
@@ -429,11 +452,20 @@ func TestToStringStringMap(t *testing.T) {
 
 			a.So(enc[StringStringMap], s.ShouldEqual, marshalToString(v.StringStringMap))
 
+			a.So(enc[Struct+".int"], s.ShouldEqual, strconv.FormatInt(int64(v.EmbStruct.Int), 10))
+
 			a.So(enc[InclStruct+".int"], s.ShouldEqual, strconv.FormatInt(int64(v.InclStruct.Int), 10))
 			a.So(enc[InclStruct+"."+SubInclStruct+".int"], s.ShouldEqual, strconv.FormatInt(int64(v.InclStruct.SubInclStruct.Int), 10))
 
 			a.So(enc[InclStructPtr+".int"], s.ShouldEqual, strconv.FormatInt(int64(v.InclStructPtr.Int), 10))
 			a.So(enc[InclStructPtr+"."+SubInclStruct+".int"], s.ShouldEqual, strconv.FormatInt(int64(v.InclStructPtr.SubInclStruct.Int), 10))
+
+			a.So(enc, s.ShouldNotContainKey, InclStructEmb+".int")
+			a.So(enc, s.ShouldNotContainKey, InclStructEmb+"."+SubInclStruct+".int")
+			a.So(enc, s.ShouldNotContainKey, InclStructEmpty+".int")
+			a.So(enc, s.ShouldNotContainKey, InclStructEmpty+"."+SubInclStruct+".int")
+			a.So(enc, s.ShouldNotContainKey, InclStructPtrEmpty+".int")
+			a.So(enc, s.ShouldNotContainKey, InclStructPtrEmpty+"."+SubInclStruct+".int")
 		})
 	}
 }
@@ -496,11 +528,20 @@ func TestToStringInterfaceMap(t *testing.T) {
 
 			a.So(enc[StringStringMap], s.ShouldResemble, v.StringStringMap)
 
+			a.So(enc[Struct+".int"], s.ShouldEqual, v.EmbStruct.Int)
+
 			a.So(enc[InclStruct+".int"], s.ShouldEqual, v.InclStruct.Int)
 			a.So(enc[InclStruct+"."+SubInclStruct+".int"], s.ShouldEqual, v.InclStruct.SubInclStruct.Int)
 
 			a.So(enc[InclStructPtr+".int"], s.ShouldEqual, v.InclStructPtr.Int)
 			a.So(enc[InclStructPtr+"."+SubInclStruct+".int"], s.ShouldEqual, v.InclStructPtr.SubInclStruct.Int)
+
+			a.So(enc, s.ShouldNotContainKey, InclStructEmb+".int")
+			a.So(enc, s.ShouldNotContainKey, InclStructEmb+"."+SubInclStruct+".int")
+			a.So(enc, s.ShouldNotContainKey, InclStructEmpty+".int")
+			a.So(enc, s.ShouldNotContainKey, InclStructEmpty+"."+SubInclStruct+".int")
+			a.So(enc, s.ShouldNotContainKey, InclStructPtrEmpty+".int")
+			a.So(enc, s.ShouldNotContainKey, InclStructPtrEmpty+"."+SubInclStruct+".int")
 		})
 	}
 }


### PR DESCRIPTION
- fixed encoding of pointers to structs
- fixed bug, where encoding would try encoding non-exported fields
- fixed bug, where encoding would not try encoding embedded structs
- made decode function not recurse on empty subInput
- added tests