### PR TITLE
Feature/log namespace

### DIFF
--- a/handlers/entries/entries.go
+++ b/handlers/entries/entries.go
@@ -1,0 +1,18 @@
+package entries
+
+import "github.com/apex/log"
+
+type Entries struct {
+	Entries []*log.Entry
+}
+
+func New() *Entries {
+	return &Entries{
+		Entries: make([]*log.Entry, 0, 10),
+	}
+}
+
+func (e *Entries) HandleLog(entry *log.Entry) error {
+	e.Entries = append(e.Entries, entry)
+	return nil
+}

--- a/handlers/entries/entries_test.go
+++ b/handlers/entries/entries_test.go
@@ -1,0 +1,37 @@
+package entries
+
+import (
+	"testing"
+
+	"github.com/apex/log"
+	"github.com/smartystreets/assertions"
+)
+
+func TestEntries(t *testing.T) {
+	a := assertions.New(t)
+
+	e := New()
+
+	e.HandleLog(&log.Entry{
+		Message: "foo",
+		Fields: log.Fields{
+			"a": 10,
+		},
+	})
+
+	a.So(len(e.Entries), assertions.ShouldEqual, 1)
+	a.So(e.Entries[0].Message, assertions.ShouldEqual, "foo")
+	a.So(e.Entries[0].Fields["a"], assertions.ShouldEqual, 10)
+
+	e.HandleLog(&log.Entry{
+		Message: "bar",
+		Fields: log.Fields{
+			"b": 20,
+		},
+	})
+
+	a.So(len(e.Entries), assertions.ShouldEqual, 2)
+	a.So(e.Entries[1].Message, assertions.ShouldEqual, "bar")
+	a.So(e.Entries[1].Fields["b"], assertions.ShouldEqual, 20)
+
+}

--- a/log/namespaced/namespaced.go
+++ b/log/namespaced/namespaced.go
@@ -23,7 +23,7 @@ func WithNamespace(namespace string, ctx log.Interface) log.Interface {
 }
 
 // Wrap wraps the logger in a Namespaced logger and enables the specified
-// namespaces
+// namespaces. See SetNamespaces for information on how to set the namspaces
 func Wrap(ctx log.Interface, namespaces ...string) *Namespaced {
 	return &Namespaced{
 		Interface: ctx,
@@ -34,6 +34,16 @@ func Wrap(ctx log.Interface, namespaces ...string) *Namespaced {
 }
 
 // SetNamespaces replaces the set of enabled namespaces
+// The namespaces follow this format:
+// "*"   enables all namespaces
+// "a"   enables namespace a
+// "-a"  disables namespace a (even if "a" or "*" is set)
+// For example:
+//  - SetNamespaces("*", "-foo") enables every namespace but foo
+//  - SetNamespaces("foo") enables only foo
+//  - SetNamespaces() disables all namespaced entries
+//
+// Note that entries without a namespace will always be logged.
 func (n *Namespaced) SetNamespaces(namespaces ...string) {
 	n.namespaces.Set(namespaces)
 }

--- a/log/namespaced/namespaced.go
+++ b/log/namespaced/namespaced.go
@@ -17,8 +17,8 @@ type Namespaced struct {
 	namespace  string
 }
 
-// Namespace adds a namespace to the logger
-func Namespace(ctx log.Interface, namespace string) log.Interface {
+// WithNamespace adds a namespace to the logging context
+func WithNamespace(namespace string, ctx log.Interface) log.Interface {
 	return ctx.WithField(NamespaceKey, namespace)
 }
 

--- a/log/namespaced/namespaced.go
+++ b/log/namespaced/namespaced.go
@@ -1,0 +1,141 @@
+package namespaced
+
+import (
+	"sync"
+
+	"github.com/TheThingsNetwork/go-utils/log"
+)
+
+var NamespaceKey = "namespace"
+
+// Namespaced is a logger that only logs an entry when the namespace of that
+// entry is enabled
+type Namespaced struct {
+	sync.RWMutex
+	log.Interface
+	namespaces *ns
+	namespace  string
+}
+
+// Namespace adds a namespace to the logger
+func Namespace(ctx log.Interface, namespace string) log.Interface {
+	return ctx.WithField(NamespaceKey, namespace)
+}
+
+// Wrap wraps the logger in a Namespaced logger and enables the specified
+// namespaces
+func Wrap(ctx log.Interface, namespaces ...string) *Namespaced {
+	return &Namespaced{
+		Interface: ctx,
+		namespaces: &ns{
+			namespaces: namespaces,
+		},
+	}
+}
+
+// SetNamespaces replaces the set of enabled namespaces
+func (n *Namespaced) SetNamespaces(namespaces ...string) {
+	n.namespaces.Set(namespaces)
+}
+
+// WithField adds a field to the logger
+func (n *Namespaced) WithField(k string, v interface{}) log.Interface {
+	if k == NamespaceKey {
+		if str, ok := v.(string); ok {
+			return &Namespaced{
+				Interface:  n.Interface,
+				namespaces: n.namespaces,
+				namespace:  str,
+			}
+		}
+	}
+
+	return &Namespaced{
+		Interface:  n.Interface.WithField(k, v),
+		namespaces: n.namespaces,
+		namespace:  n.namespace,
+	}
+}
+
+// WithFields adds multiple fields to the logger
+func (n *Namespaced) WithFields(fields log.Fields) log.Interface {
+	return &Namespaced{
+		Interface:  n.Interface.WithFields(fields),
+		namespaces: n.namespaces,
+		namespace:  n.namespace,
+	}
+}
+
+func (n *Namespaced) WithError(err error) log.Interface {
+	return &Namespaced{
+		Interface:  n.Interface.WithError(err),
+		namespaces: n.namespaces,
+		namespace:  n.namespace,
+	}
+}
+
+// isEnabdled returns wether or not this Namespaced logger should log or not
+// based on the enabled namespaces and the namespace
+func (n *Namespaced) isEnabled() bool {
+	return n.namespaces.IsEnabled(n.namespace)
+}
+
+func (n *Namespaced) Debug(msg string) {
+	if n.isEnabled() {
+		n.Interface.Debug(msg)
+	}
+}
+
+func (n *Namespaced) Debugf(msg string, v ...interface{}) {
+	if n.isEnabled() {
+		n.Interface.Debugf(msg, v...)
+	}
+}
+
+func (n *Namespaced) Info(msg string) {
+	if n.isEnabled() {
+		n.Interface.Info(msg)
+	}
+}
+
+func (n *Namespaced) Infof(msg string, v ...interface{}) {
+	if n.isEnabled() {
+		n.Interface.Infof(msg, v...)
+	}
+}
+
+func (n *Namespaced) Warn(msg string) {
+	if n.isEnabled() {
+		n.Interface.Warn(msg)
+	}
+}
+
+func (n *Namespaced) Warnf(msg string, v ...interface{}) {
+	if n.isEnabled() {
+		n.Interface.Warnf(msg, v...)
+	}
+}
+
+func (n *Namespaced) Error(msg string) {
+	if n.isEnabled() {
+		n.Interface.Error(msg)
+	}
+}
+
+func (n *Namespaced) Errorf(msg string, v ...interface{}) {
+	if n.isEnabled() {
+		n.Interface.Errorf(msg, v...)
+	}
+}
+
+func (n *Namespaced) Fatal(msg string) {
+	if n.isEnabled() {
+		n.Interface.Fatal(msg)
+	}
+}
+
+func (n *Namespaced) Fatalf(msg string, v ...interface{}) {
+	if n.isEnabled() {
+		n.Interface.Fatalf(msg, v...)
+	}
+}

--- a/log/namespaced/namespaced.go
+++ b/log/namespaced/namespaced.go
@@ -84,7 +84,7 @@ func (n *Namespaced) WithError(err error) log.Interface {
 	}
 }
 
-// isEnabdled returns wether or not this Namespaced logger should,
+// isEnabdled returns wether or not this Namespaced logger should log,
 // based on the enabled namespaces and the namespace
 func (n *Namespaced) isEnabled() bool {
 	return n.namespaces.IsEnabled(n.namespace)

--- a/log/namespaced/namespaced.go
+++ b/log/namespaced/namespaced.go
@@ -84,7 +84,7 @@ func (n *Namespaced) WithError(err error) log.Interface {
 	}
 }
 
-// isEnabdled returns wether or not this Namespaced logger should log or not
+// isEnabdled returns wether or not this Namespaced logger should,
 // based on the enabled namespaces and the namespace
 func (n *Namespaced) isEnabled() bool {
 	return n.namespaces.IsEnabled(n.namespace)

--- a/log/namespaced/namespaced.go
+++ b/log/namespaced/namespaced.go
@@ -84,7 +84,7 @@ func (n *Namespaced) WithError(err error) log.Interface {
 	}
 }
 
-// isEnabdled returns wether or not this Namespaced logger should log,
+// isEnabdled returns whether or not this Namespaced logger should log,
 // based on the enabled namespaces and the namespace
 func (n *Namespaced) isEnabled() bool {
 	return n.namespaces.IsEnabled(n.namespace)

--- a/log/namespaced/namespaced_test.go
+++ b/log/namespaced/namespaced_test.go
@@ -1,0 +1,65 @@
+package namespaced
+
+import (
+	"testing"
+
+	"github.com/TheThingsNetwork/go-utils/handlers/entries"
+	apx "github.com/TheThingsNetwork/go-utils/log/apex"
+	apex "github.com/apex/log"
+	. "github.com/smartystreets/assertions"
+)
+
+func TestNamespaced(t *testing.T) {
+	a := New(t)
+
+	handler := entries.New()
+
+	ctx := Wrap(apx.Wrap(&apex.Logger{
+		Level:   apex.DebugLevel,
+		Handler: handler,
+	}))
+
+	// should just log messages without a namespace
+	{
+		ctx.Info("message")
+		a.So(len(handler.Entries), ShouldEqual, 1)
+	}
+
+	// should just log messages without a namespace
+	// even when a namespace is set
+	{
+		ctx.SetNamespaces("foo")
+		ctx.Info("message 2")
+		a.So(len(handler.Entries), ShouldEqual, 2)
+	}
+
+	// correctly namespaced loggers should log
+	{
+		foo := Namespace(ctx, "foo")
+		foo.Info("message 3")
+		a.So(len(handler.Entries), ShouldEqual, 3)
+	}
+
+	// incorrectly namespaced loggers should not log
+	{
+		bar := Namespace(ctx, "bar")
+		bar.Info("message 4 (bar) should be ignored")
+		a.So(len(handler.Entries), ShouldEqual, 3)
+
+		// set the namspaces to include bar and log bar
+		ctx.SetNamespaces("foo", "bar")
+		bar.Info("message 5 (bar)")
+		a.So(len(handler.Entries), ShouldEqual, 4)
+
+		// set the namspaces to include bar and log bar
+		ctx.SetNamespaces()
+		bar.Info("message 6 (bar) should be ignored")
+		a.So(len(handler.Entries), ShouldEqual, 4)
+	}
+
+	for _, entry := range handler.Entries {
+		// fmt.Println(entry.Message)
+		a.So(entry.Message, ShouldNotEndWith, "should be ignored")
+		a.So(entry.Fields, ShouldNotContainKey, "namespace")
+	}
+}

--- a/log/namespaced/namespaced_test.go
+++ b/log/namespaced/namespaced_test.go
@@ -35,14 +35,14 @@ func TestNamespaced(t *testing.T) {
 
 	// correctly namespaced loggers should log
 	{
-		foo := Namespace(ctx, "foo")
+		foo := WithNamespace("foo", ctx)
 		foo.Info("message 3")
 		a.So(len(handler.Entries), ShouldEqual, 3)
 	}
 
 	// incorrectly namespaced loggers should not log
 	{
-		bar := Namespace(ctx, "bar")
+		bar := WithNamespace("bar", ctx)
 		bar.Info("message 4 (bar) should be ignored")
 		a.So(len(handler.Entries), ShouldEqual, 3)
 

--- a/log/namespaced/namespaced_test.go
+++ b/log/namespaced/namespaced_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/TheThingsNetwork/go-utils/handlers/entries"
-	apx "github.com/TheThingsNetwork/go-utils/log/apex"
+	apex_wrapper "github.com/TheThingsNetwork/go-utils/log/apex"
 	apex "github.com/apex/log"
 	. "github.com/smartystreets/assertions"
 )
@@ -14,7 +14,7 @@ func TestNamespaced(t *testing.T) {
 
 	handler := entries.New()
 
-	ctx := Wrap(apx.Wrap(&apex.Logger{
+	ctx := Wrap(apex_wrapper.Wrap(&apex.Logger{
 		Level:   apex.DebugLevel,
 		Handler: handler,
 	}))

--- a/log/namespaced/namespaces.go
+++ b/log/namespaced/namespaces.go
@@ -1,0 +1,53 @@
+package namespaced
+
+import "sync"
+
+type ns struct {
+	sync.RWMutex
+	namespaces []string
+}
+
+// negate negates the namspace
+func negate(namespace string) string {
+	return "-" + namespace
+}
+
+// isEnabled checks wether or not the namespace is enabled
+func (n *ns) IsEnabled(namespace string) bool {
+	n.RLock()
+	defer n.RUnlock()
+
+	if namespace == "" {
+		return true
+	}
+
+	hasStar := false
+	included := false
+
+	for _, ns := range n.namespaces {
+		// if the namspace is negated, it can never be enabled
+		if ns == negate(namespace) {
+			return false
+		}
+
+		// if the namespace is explicitly enabled, mark it as included
+		if ns == namespace {
+			included = true
+		}
+
+		// mark that we have a *
+		if ns == "*" {
+			hasStar = true
+		}
+	}
+
+	// non-mentioned namespaces are only enabled if we got the catch-all *
+	return hasStar || included
+}
+
+// Set updates the namespaces
+func (n *ns) Set(namespaces []string) {
+	n.Lock()
+	defer n.Unlock()
+	n.namespaces = namespaces
+}

--- a/log/namespaced/namespaces_test.go
+++ b/log/namespaced/namespaces_test.go
@@ -1,0 +1,86 @@
+package namespaced
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/assertions"
+)
+
+func TestNamespaces(t *testing.T) {
+	a := New(t)
+
+	ns := &ns{}
+
+	// empty namespace is accepted
+	{
+		ns.Set([]string{})
+
+		a.So(ns.IsEnabled("a"), ShouldBeFalse)
+		a.So(ns.IsEnabled("b"), ShouldBeFalse)
+		a.So(ns.IsEnabled("c"), ShouldBeFalse)
+		a.So(ns.IsEnabled(""), ShouldBeTrue)
+	}
+
+	// add some namespaces
+	{
+		ns.Set([]string{
+			"a",
+			"b",
+		})
+
+		a.So(ns.IsEnabled("a"), ShouldBeTrue)
+		a.So(ns.IsEnabled("b"), ShouldBeTrue)
+		a.So(ns.IsEnabled("c"), ShouldBeFalse)
+		a.So(ns.IsEnabled(""), ShouldBeTrue)
+	}
+
+	// * accepts everything
+	{
+		ns.Set([]string{
+			"*",
+		})
+
+		a.So(ns.IsEnabled("a"), ShouldBeTrue)
+		a.So(ns.IsEnabled("b"), ShouldBeTrue)
+		a.So(ns.IsEnabled("c"), ShouldBeTrue)
+		a.So(ns.IsEnabled(""), ShouldBeTrue)
+	}
+
+	// negation wins from *
+	{
+		ns.Set([]string{
+			"*",
+			"-a",
+		})
+
+		a.So(ns.IsEnabled("a"), ShouldBeFalse)
+		a.So(ns.IsEnabled("b"), ShouldBeTrue)
+		a.So(ns.IsEnabled("c"), ShouldBeTrue)
+		a.So(ns.IsEnabled(""), ShouldBeTrue)
+	}
+
+	// order should not matter
+	{
+		ns.Set([]string{
+			"-a",
+			"-b",
+			"*",
+		})
+
+		a.So(ns.IsEnabled("a"), ShouldBeFalse)
+		a.So(ns.IsEnabled("b"), ShouldBeFalse)
+		a.So(ns.IsEnabled("c"), ShouldBeTrue)
+		a.So(ns.IsEnabled(""), ShouldBeTrue)
+	}
+
+	// negation always wins
+	{
+		ns.Set([]string{
+			"a",
+			"-a",
+		})
+
+		a.So(ns.IsEnabled("a"), ShouldBeFalse)
+		a.So(ns.IsEnabled(""), ShouldBeTrue)
+	}
+}


### PR DESCRIPTION
Adds a log wrapper that filters log entries based on namespaces.

```
ctx := namespaced.Wrap(prevCtx)

ctx.SetNamespaces("foo")

foo := namespaced.WithNamespace("foo", ctx)
bar := namespaced.WithNamespace("bar", ctx)

foo.Info("Hello!") // will log
bar.Info("Hello!") // will not log

ctx.SetNamespaces("foo", "bar")
bar.Info("Hello!") // will now also log
```

Also adds a handler `Entries` that can be used for testing.