### PR TITLE
Make stats package use log

### DIFF
--- a/stats/stats.go
+++ b/stats/stats.go
@@ -7,7 +7,7 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/apex/log"
+	"github.com/TheThingsNetwork/go-utils/log"
 )
 
 var megaByte = float64(1024 * 1024)


### PR DESCRIPTION
Make the stats package use the `go-utils` `log` package.