### PR TITLE
Encoding: support `squash` tag

### DIFF
--- a/encoding/doc.go
+++ b/encoding/doc.go
@@ -1,0 +1,6 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+// Package encoding is responsible for encoding and decoding of structs.
+// `squash` option assumes that field names are unique in structs, otherwise results are unpredictable
+package encoding

--- a/encoding/encode.go
+++ b/encoding/encode.go
@@ -89,6 +89,10 @@ func ToStringStringMap(tagName string, input interface{}, properties ...string) 
 		if kind == reflect.Ptr {
 			v := reflect.ValueOf(val)
 			if v.IsNil() {
+				if _, ok := vmap[fieldName]; ok {
+					panic(fmt.Errorf("field names not unique(%s)", fieldName))
+				}
+
 				if fieldName != "" && fieldName != "-" {
 					vmap[fieldName] = ""
 				}

--- a/encoding/encoding_test.go
+++ b/encoding/encoding_test.go
@@ -44,6 +44,11 @@ var (
 	stringStringMapVar = map[string]string{"te": "st"}
 
 	inclStructVar = inclStruct{Int: intVar, SubInclStruct: subInclStruct{Int: intVar}}
+
+	SquashedFieldVar  = "squashed field"
+	squashedStructVar = SquashedStruct{
+		SquashedField: SquashedFieldVar,
+	}
 )
 
 var (
@@ -112,6 +117,8 @@ const (
 
 	EmbStructTag    = "embStruct"
 	EmbInterfaceTag = "embInterface"
+
+	SquashedField = "squashedField"
 )
 
 type inclStruct struct {
@@ -128,6 +135,10 @@ type EmbStruct struct {
 }
 type EmbInterface interface {
 	Test()
+}
+
+type SquashedStruct struct {
+	SquashedField string `test:"squashedField"`
 }
 type testStruct struct {
 	Int     int     `test:"int"`
@@ -172,6 +183,8 @@ type testStruct struct {
 
 	EmbStruct    `test:"embStruct,include"`
 	EmbInterface `test:"embInterface,include"`
+
+	SquashedStruct `test:",squash"`
 
 	InclStruct         inclStruct  `test:"inclStruct,include"`
 	InclStructEmpty    inclStruct  `test:"inclStructEmpty,include,omitempty"`
@@ -245,6 +258,8 @@ func TestFromStringStringMap(t *testing.T) {
 
 				InclStructEmb + "." + Int:                       strconv.Itoa(intVar),
 				InclStructEmb + "." + SubInclStruct + "." + Int: strconv.Itoa(intVar),
+
+				SquashedField: SquashedFieldVar,
 			}
 
 			ret, err := FromStringStringMap(testTag, arg, m)
@@ -329,6 +344,8 @@ func TestFromStringStringMap(t *testing.T) {
 
 			a.So(v.EmbStruct.Int, s.ShouldEqual, func() int { val, _ := strconv.ParseInt(m[EmbStructTag+"."+Int], 10, 0); return int(val) }())
 
+			a.So(v.SquashedStruct.SquashedField, s.ShouldEqual, SquashedFieldVar)
+
 			a.So(v.InclStruct.Int, s.ShouldEqual, func() int { val, _ := strconv.ParseInt(m[InclStruct+"."+Int], 10, 0); return int(val) }())
 			a.So(v.InclStruct.SubInclStruct.Int, s.ShouldEqual, func() int {
 				val, _ := strconv.ParseInt(m[InclStruct+"."+SubInclStruct+"."+Int], 10, 0)
@@ -395,6 +412,8 @@ var testStructVar = testStruct{
 	InclStructPtr: &inclStructVar,
 
 	inclStruct: inclStructVar,
+
+	SquashedStruct: squashedStructVar,
 }
 
 func TestToStringStringMap(t *testing.T) {
@@ -457,6 +476,8 @@ func TestToStringStringMap(t *testing.T) {
 
 			a.So(enc[EmbStructTag+".int"], s.ShouldEqual, strconv.FormatInt(int64(v.EmbStruct.Int), 10))
 
+			a.So(enc[SquashedField], s.ShouldEqual, SquashedFieldVar)
+
 			a.So(enc[InclStruct+".int"], s.ShouldEqual, strconv.FormatInt(int64(v.InclStruct.Int), 10))
 			a.So(enc[InclStruct+"."+SubInclStruct+".int"], s.ShouldEqual, strconv.FormatInt(int64(v.InclStruct.SubInclStruct.Int), 10))
 
@@ -504,7 +525,6 @@ func TestToStringStringMap(t *testing.T) {
 				a.So(enc[BoolPtr], s.ShouldEqual, "")
 				a.So(enc[StringPtr], s.ShouldEqual, "")
 			}
-
 		})
 	}
 }
@@ -568,6 +588,8 @@ func TestToStringInterfaceMap(t *testing.T) {
 			a.So(enc[StringStringMap], s.ShouldResemble, v.StringStringMap)
 
 			a.So(enc[EmbStructTag+".int"], s.ShouldEqual, v.EmbStruct.Int)
+
+			a.So(enc[SquashedField], s.ShouldEqual, SquashedFieldVar)
 
 			a.So(enc[InclStruct+".int"], s.ShouldEqual, v.InclStruct.Int)
 			a.So(enc[InclStruct+"."+SubInclStruct+".int"], s.ShouldEqual, v.InclStruct.SubInclStruct.Int)


### PR DESCRIPTION
"Squashed" struct fields are flattened in the map
Assume 
```go
type Bar struct {
	Field int `tag:"field"`
}

type Foo struct {
	Bar `tag:",squash"`
}

var x = Foo{
	Bar: Bar{
		Field: 42,
	},
}
```

in a map produced by encoding `x`, value under key `field` would be equal to `x.Bar.Field`

This assumes that struct field names are unique

- [ ] add documentation