### PR TITLE
gRPC Auth

### DIFF
--- a/grpc/auth/auth.go
+++ b/grpc/auth/auth.go
@@ -1,0 +1,67 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package auth
+
+import (
+	"github.com/TheThingsNetwork/go-utils/grpc/ttnctx"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+)
+
+const tokenKey = "token"
+
+// TokenCredentials RPC Credentials
+type TokenCredentials struct {
+	allowInsecure bool
+	token         string
+	tokenFunc     func(id string) string
+	tokenFuncKey  string
+}
+
+// WithInsecure returns a copy of the TokenCredentials, allowing insecure transport
+func (c *TokenCredentials) WithInsecure() *TokenCredentials {
+	return &TokenCredentials{token: c.token, tokenFunc: c.tokenFunc, allowInsecure: true}
+}
+
+// WithStaticToken injects a static token on each request
+func WithStaticToken(token string) *TokenCredentials {
+	return &TokenCredentials{
+		token: token,
+	}
+}
+
+// WithTokenFunc returns TokenCredentials that execute the tokenFunc on each request
+// The value of v sent to the tokenFunk is the MD value of the supplied k
+func WithTokenFunc(k string, tokenFunc func(v string) string) *TokenCredentials {
+	return &TokenCredentials{
+		tokenFunc:    tokenFunc,
+		tokenFuncKey: k,
+	}
+}
+
+// RequireTransportSecurity implements credentials.PerRPCCredentials
+func (c *TokenCredentials) RequireTransportSecurity() bool { return !c.allowInsecure }
+
+// GetRequestMetadata implements credentials.PerRPCCredentials
+func (c *TokenCredentials) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
+	md := ttnctx.MetadataFromOutgoingContext(ctx)
+	token, _ := ttnctx.TokenFromMetadata(md)
+	if token != "" {
+		return map[string]string{tokenKey: token}, nil
+	}
+	if c.tokenFunc != nil {
+		if v, ok := md[c.tokenFuncKey]; ok && len(v) > 0 {
+			return map[string]string{tokenKey: c.tokenFunc(v[0])}, nil
+		}
+	}
+	if c.token != "" {
+		return map[string]string{tokenKey: c.token}, nil
+	}
+	return map[string]string{tokenKey: ""}, nil
+}
+
+// DialOption returns a DialOption for the TokenCredentials
+func (c *TokenCredentials) DialOption() grpc.DialOption {
+	return grpc.WithPerRPCCredentials(c)
+}

--- a/grpc/auth/auth.go
+++ b/grpc/auth/auth.go
@@ -51,9 +51,11 @@ func (c *TokenCredentials) GetRequestMetadata(ctx context.Context, uri ...string
 		return map[string]string{tokenKey: token}, nil
 	}
 	if c.tokenFunc != nil {
+		var k string
 		if v, ok := md[c.tokenFuncKey]; ok && len(v) > 0 {
-			return map[string]string{tokenKey: c.tokenFunc(v[0])}, nil
+			k = v[0]
 		}
+		return map[string]string{tokenKey: c.tokenFunc(k)}, nil
 	}
 	if c.token != "" {
 		return map[string]string{tokenKey: c.token}, nil

--- a/grpc/auth/auth_test.go
+++ b/grpc/auth/auth_test.go
@@ -1,0 +1,40 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package auth
+
+import (
+	"testing"
+
+	"github.com/TheThingsNetwork/go-utils/grpc/ttnctx"
+	. "github.com/smartystreets/assertions"
+	"golang.org/x/net/context"
+)
+
+func TestAuth(t *testing.T) {
+	a := New(t)
+	var err error
+
+	c := WithStaticToken("token")
+	md, err := c.GetRequestMetadata(context.Background())
+	a.So(err, ShouldBeNil)
+	a.So(md, ShouldContainKey, "token")
+	a.So(md["token"], ShouldEqual, "token")
+
+	md, err = c.GetRequestMetadata(ttnctx.OutgoingContextWithToken(context.Background(), "existingtoken"))
+	a.So(err, ShouldBeNil)
+	a.So(md, ShouldContainKey, "token")
+	a.So(md["token"], ShouldEqual, "existingtoken")
+
+	a.So(c.RequireTransportSecurity(), ShouldBeTrue)
+	a.So(c.WithInsecure().RequireTransportSecurity(), ShouldBeFalse)
+
+	c = WithTokenFunc("id", func(id string) string {
+		return id
+	})
+
+	md, err = c.GetRequestMetadata(ttnctx.OutgoingContextWithID(context.Background(), "id"))
+	a.So(err, ShouldBeNil)
+	a.So(md, ShouldContainKey, "token")
+	a.So(md["token"], ShouldEqual, "id")
+}


### PR DESCRIPTION
The auth package (based on the one in TheThingsNetwork/ttn) is used to add authentication as the last step before the RPC is sent. As other interceptors are executed before this is done, up-to-daqte authentication is inserted even if a stream is restarted by the `restartstream` package. Pretty nice, right?