### PR TITLE
[RFC] Portable errors

### DIFF
--- a/errors/cause.go
+++ b/errors/cause.go
@@ -1,0 +1,32 @@
+package errors
+
+import "errors"
+
+const causeKey = "cause"
+
+// Causer is the type of errors that can have a cause
+type Causer interface {
+	Cause() error
+}
+
+// Cause returns the cause of an error
+func Cause(err Error) error {
+	attributes := err.Attributes()
+	if attributes == nil {
+		return nil
+	}
+
+	cause, ok := attributes[causeKey]
+	if !ok {
+		return nil
+	}
+
+	switch v := cause.(type) {
+	case error:
+		return v
+	case string:
+		return errors.New(v)
+	default:
+		return nil
+	}
+}

--- a/errors/descriptor.go
+++ b/errors/descriptor.go
@@ -38,7 +38,7 @@ func (err *ErrDescriptor) New(attributes Attributes) Error {
 	}
 
 	return &impl{
-		message:    Format(err.MessageFormat, attributes, defaultValueFormatter),
+		message:    Format(err.MessageFormat, attributes),
 		code:       err.Code,
 		typ:        err.Type,
 		attributes: attributes,

--- a/errors/descriptor.go
+++ b/errors/descriptor.go
@@ -1,0 +1,56 @@
+package errors
+
+import "fmt"
+
+// ErrDescriptor is a helper struct to easily build new Errors from and to be
+// the authoritive information about error codes.
+//
+// The descriptor can be used to find out information about the error after it
+// has been handed over between components
+type ErrDescriptor struct {
+	// MessageFormat is the format of the error message. Attributes will be filled
+	// in when an error is created using New(). For example:
+	//
+	//   "This is an error about user {username}"
+	//
+	// when passed an atrtributes map with "username" set to "john" would interpolate to
+	//
+	//   "This is an error about user john"
+	//
+	// The idea about this message format is that is is localizable
+	MessageFormat string
+
+	// Code is the code of errors that are created by this descriptor
+	Code Code
+
+	// Type is the type of errors created by this descriptor
+	Type Type
+
+	// registered denotes wether or not the error has been registered
+	// (by a call to Register)
+	registered bool
+}
+
+// Format formats the attributes into an Error
+func (err *ErrDescriptor) New(attributes Attributes) Error {
+	if !err.registered {
+		panic(fmt.Errorf("Error descriptor with code %v was not registered", err.Code))
+	}
+
+	return &impl{
+		message:    Format(err.MessageFormat, attributes, defaultValueFormatter),
+		code:       err.Code,
+		typ:        err.Type,
+		attributes: attributes,
+	}
+}
+
+// New creates a new Error from a descriptor and some attributes
+func New(descriptor *ErrDescriptor, attributes Attributes) Error {
+	return descriptor.New(attributes)
+}
+
+// Register registers the descriptor
+func (err *ErrDescriptor) Register() {
+	Register(err)
+}

--- a/errors/descriptor_test.go
+++ b/errors/descriptor_test.go
@@ -1,0 +1,28 @@
+package errors
+
+import (
+	"testing"
+
+	"github.com/smartystreets/assertions"
+)
+
+func TestDescriptor(t *testing.T) {
+	a := assertions.New(t)
+
+	d := &ErrDescriptor{
+		MessageFormat: "You do not have access to app with id {app_id}",
+		Code:          77,
+		Type:          PermissionDenied,
+		registered:    true,
+	}
+
+	attributes := Attributes{
+		"app_id": "foo",
+	}
+	err := New(d, attributes)
+
+	a.So(err.Error(), assertions.ShouldEqual, "You do not have access to app with id foo")
+	a.So(err.Code(), assertions.ShouldEqual, d.Code)
+	a.So(err.Type(), assertions.ShouldEqual, d.Type)
+	a.So(err.Attributes(), assertions.ShouldResemble, attributes)
+}

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,6 +1,6 @@
 package errors
 
-// Error is the interface og grpc errors
+// Error is the interface of portable errors
 type Error interface {
 	error
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,0 +1,22 @@
+package errors
+
+// Error is the interface og grpc errors
+type Error interface {
+	// Error returns the formatted error message
+	Error() string
+
+	// Code returns the error code
+	Code() Code
+
+	// Type returns the error type
+	Type() Type
+
+	// Attributes returns the error attributes
+	Attributes() Attributes
+}
+
+// Code represents a unique error code
+type Code uint32
+
+// Attributes
+type Attributes map[string]interface{}

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -2,8 +2,7 @@ package errors
 
 // Error is the interface og grpc errors
 type Error interface {
-	// Error returns the formatted error message
-	Error() string
+	error
 
 	// Code returns the error code
 	Code() Code

--- a/errors/format.go
+++ b/errors/format.go
@@ -1,0 +1,27 @@
+package errors
+
+import (
+	"fmt"
+	"regexp"
+)
+
+type ValueFormatter func(interface{}) string
+
+func defaultValueFormatter(v interface{}) string {
+	return fmt.Sprintf("%v", v)
+}
+
+// re finds names in the format string
+var re = regexp.MustCompile("{(.+?)}")
+
+// Format formats the values into the provided string
+func Format(format string, values Attributes, formatValue ValueFormatter) string {
+	return re.ReplaceAllStringFunc(format, func(name string) string {
+		if values == nil {
+			return "<nil>"
+		}
+
+		stripped := name[1 : len(name)-1]
+		return formatValue(values[stripped])
+	})
+}

--- a/errors/format.go
+++ b/errors/format.go
@@ -2,26 +2,63 @@ package errors
 
 import (
 	"fmt"
-	"regexp"
+	"reflect"
+
+	"github.com/gotnospirit/messageformat"
 )
 
-type ValueFormatter func(interface{}) string
+// Format formats the values into the provided string
+func Format(format string, values Attributes) string {
+	formatter, err := messageformat.New()
+	if err != nil {
+		return format
+	}
 
-func defaultValueFormatter(v interface{}) string {
-	return fmt.Sprintf("%v", v)
+	fm, err := formatter.Parse(format)
+	if err != nil {
+		return format
+	}
+
+	fixed := make(map[string]interface{}, len(values))
+	for k, v := range values {
+		fixed[k] = fix(v)
+	}
+
+	// todo format unsupported types
+	res, err := fm.FormatMap(fixed)
+	if err != nil {
+		fmt.Println("err", err)
+		return format
+	}
+
+	return res
 }
 
-// re finds names in the format string
-var re = regexp.MustCompile("{(.+?)}")
+// Fix coerces types that cannot be formatted by messageformat to string
+func fix(v interface{}) interface{} {
+	if v == nil {
+		return "<nil>"
+	}
 
-// Format formats the values into the provided string
-func Format(format string, values Attributes, formatValue ValueFormatter) string {
-	return re.ReplaceAllStringFunc(format, func(name string) string {
-		if values == nil {
-			return "<nil>"
-		}
-
-		stripped := name[1 : len(name)-1]
-		return formatValue(values[stripped])
-	})
+	switch reflect.TypeOf(v).Kind() {
+	case reflect.Bool:
+	case reflect.Int:
+	case reflect.Int8:
+	case reflect.Int16:
+	case reflect.Int32:
+	case reflect.Int64:
+	case reflect.Uint:
+	case reflect.Uint8:
+	case reflect.Uint16:
+	case reflect.Uint32:
+	case reflect.Uint64:
+	case reflect.Uintptr:
+	case reflect.Float32:
+	case reflect.Float64:
+		return v
+	case reflect.Ptr:
+		// dereference and fix
+		return fix(reflect.ValueOf(v).Elem())
+	}
+	return fmt.Sprintf("%v", v)
 }

--- a/errors/format_test.go
+++ b/errors/format_test.go
@@ -1,0 +1,22 @@
+package errors
+
+import (
+	"testing"
+
+	"github.com/smartystreets/assertions"
+)
+
+func TestFormat(t *testing.T) {
+	a := assertions.New(t)
+
+	format := "{foo} - {bar} - {nil} - {list} - {map}"
+	{
+		res := Format(format, Attributes{
+			"foo":  10,
+			"bar":  "bar",
+			"list": []int{1, 2, 3},
+			"map":  map[string]int{"ok": 1},
+		}, defaultValueFormatter)
+		a.So(res, assertions.ShouldEqual, "10 - bar - <nil> - [1 2 3] - map[ok:1]")
+	}
+}

--- a/errors/format_test.go
+++ b/errors/format_test.go
@@ -6,17 +6,39 @@ import (
 	"github.com/smartystreets/assertions"
 )
 
+func TestFormatTypes(t *testing.T) {
+	a := assertions.New(t)
+
+	format := "{foo} - {bar} - {nil} - {list} - {map} - {complex} - {ptr}"
+	{
+		val := 10
+		res := Format(format, Attributes{
+			"foo":     10,
+			"bar":     "bar",
+			"nil":     nil,
+			"list":    []int{1, 2, 3},
+			"map":     map[string]int{"ok": 1},
+			"complex": 3 + 4i,
+			"ptr":     &val,
+		})
+		a.So(res, assertions.ShouldEqual, "10 - bar - <nil> - [1 2 3] - map[ok:1] - (3+4i) - 10")
+	}
+}
+
 func TestFormat(t *testing.T) {
 	a := assertions.New(t)
 
-	format := "{foo} - {bar} - {nil} - {list} - {map}"
+	format := "Found {foo, plural, =0 {no foos} =1 {# foo} other {# foos}}"
 	{
 		res := Format(format, Attributes{
-			"foo":  10,
-			"bar":  "bar",
-			"list": []int{1, 2, 3},
-			"map":  map[string]int{"ok": 1},
-		}, defaultValueFormatter)
-		a.So(res, assertions.ShouldEqual, "10 - bar - <nil> - [1 2 3] - map[ok:1]")
+			"foo": 1,
+		})
+		a.So(res, assertions.ShouldEqual, "Found 1 foo")
+	}
+	{
+		res := Format(format, Attributes{
+			"foo": 0,
+		})
+		a.So(res, assertions.ShouldEqual, "Found no foos")
 	}
 }

--- a/errors/grpc.go
+++ b/errors/grpc.go
@@ -1,0 +1,22 @@
+package errors
+
+import (
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+)
+
+// GRPCCode returns the corresponding http status code from an error type
+func (t Type) GRPCCode() codes.Code {
+	// TODO
+	return codes.Unknown
+}
+
+// GRPCCode returns the corresponding http status code from an error
+func GRPCCode(err error) codes.Code {
+	e, ok := err.(Error)
+	if ok {
+		return e.Type().GRPCCode()
+	}
+
+	return grpc.Code(err)
+}

--- a/errors/http.go
+++ b/errors/http.go
@@ -1,0 +1,54 @@
+package errors
+
+import "net/http"
+
+// HTTPStatusCode returns the corresponding http status code from an error type
+func (t Type) HTTPStatusCode() int {
+	switch t {
+	case InvalidArgument:
+	case OutOfRange:
+		return http.StatusBadRequest
+
+	case NotFound:
+		return http.StatusNotFound
+
+	case Conflict:
+	case AlreadyExists:
+		return http.StatusConflict
+
+	case Unauthorized:
+		return http.StatusUnauthorized
+
+	case PermissionDenied:
+		return http.StatusForbidden
+
+	case Timeout:
+		return http.StatusRequestTimeout
+
+	case NotImplemented:
+		return http.StatusNotImplemented
+
+	case TemporarilyUnavailable:
+		return http.StatusBadGateway
+
+	case PermanentlyUnavailable:
+		return http.StatusGone
+
+	case Unknown:
+	case Internal:
+		return http.StatusInternalServerError
+	}
+
+	return http.StatusInternalServerError
+}
+
+// HTTPStatusCode returns the HTTP status code for the given error
+// or 500 if it doesn't know
+func HTTPStatusCode(err error) int {
+	e, ok := err.(Error)
+	if ok {
+		return e.Type().HTTPStatusCode()
+	}
+
+	return http.StatusInternalServerError
+}

--- a/errors/impl.go
+++ b/errors/impl.go
@@ -1,0 +1,29 @@
+package errors
+
+// impl implements Error
+type impl struct {
+	message    string
+	code       Code
+	typ        Type
+	attributes Attributes
+}
+
+// Error returns the formatted error message
+func (i *impl) Error() string {
+	return i.message
+}
+
+// Code returns the error code
+func (i *impl) Code() Code {
+	return i.code
+}
+
+// Type returns the error type
+func (i *impl) Type() Type {
+	return i.typ
+}
+
+// Attributes returns the error attributes
+func (i *impl) Attributes() Attributes {
+	return i.attributes
+}

--- a/errors/registry.go
+++ b/errors/registry.go
@@ -41,8 +41,10 @@ var reg = &registry{
 }
 
 // Register registers a new error descriptor
-func Register(descriptor *ErrDescriptor) {
-	reg.Register(descriptor)
+func Register(descriptors ...*ErrDescriptor) {
+	for _, descriptor := range descriptors {
+		reg.Register(descriptor)
+	}
 }
 
 // Get returns an error descriptor based on an error code

--- a/errors/registry.go
+++ b/errors/registry.go
@@ -1,0 +1,105 @@
+package errors
+
+import (
+	"fmt"
+	"sync"
+)
+
+// registry represents an error type registry
+type registry struct {
+	sync.RWMutex
+	byCode map[Code]*ErrDescriptor
+}
+
+// Register registers a new error type
+func (r *registry) Register(err *ErrDescriptor) {
+	r.Lock()
+	defer r.Unlock()
+
+	if err.Code == 0 {
+		panic(fmt.Errorf("No code defined in error descriptor (message: `%s`)", err.MessageFormat))
+	}
+
+	if r.byCode[err.Code] != nil {
+		panic(fmt.Errorf("errors: Duplicate error code %v registered", err.Code))
+	}
+
+	err.registered = true
+	r.byCode[err.Code] = err
+}
+
+// Get returns the descriptor if it exists or nil otherwise
+func (r *registry) Get(code Code) *ErrDescriptor {
+	r.RLock()
+	defer r.RUnlock()
+	return r.byCode[code]
+}
+
+// reg is a global registry to be shared by packages
+var reg = &registry{
+	byCode: make(map[Code]*ErrDescriptor),
+}
+
+// Register registers a new error descriptor
+func Register(descriptor *ErrDescriptor) {
+	reg.Register(descriptor)
+}
+
+// Get returns an error descriptor based on an error code
+func Get(code Code) *ErrDescriptor {
+	return reg.Get(code)
+}
+
+// Descriptor returns the error descriptor from any error
+func Descriptor(err error) (desc *ErrDescriptor) {
+	var code Code
+
+	// let's hope it's an Error
+	e, ok := err.(Error)
+	if ok {
+		code = e.Code()
+		desc = Get(code)
+	}
+
+	// TODO: try to get from http or grpc errors
+
+	// if the descriptor was found, return it
+	if desc != nil {
+		return desc
+	}
+
+	// return a new error descriptor with sane defaults
+	return &ErrDescriptor{
+		MessageFormat: err.Error(),
+		Type:          Unknown,
+		Code:          code,
+	}
+}
+
+// GetCode infers the error code from the error
+func GetCode(err error) Code {
+	return Descriptor(err).Code
+}
+
+// GetMessageFormat infers the message format from the error
+// or falls back to the error message
+func GetMessageFormat(err error) string {
+	return Descriptor(err).MessageFormat
+}
+
+// GetType infers the error type from the error
+// or falls back to Unknown
+func GetType(err error) Type {
+	return Descriptor(err).Type
+}
+
+// GetAttributes returns the error attributes or falls back
+// to empty attributes
+func GetAttributes(err error) Attributes {
+	e, ok := err.(Error)
+	if ok {
+		return e.Attributes()
+	}
+
+	return Attributes{}
+}

--- a/errors/type.go
+++ b/errors/type.go
@@ -1,0 +1,53 @@
+package errors
+
+type Type uint8
+
+const (
+	// Unknown is the type of unknown or unexpected errors
+	Unknown Type = iota
+
+	// Internal is the type of internal errors
+	Internal
+
+	// InvalidArgument is the type of errors that result from an invalid argument
+	// in a request
+	InvalidArgument
+
+	// OutOfRange is the type of errors that result from an out of range request
+	OutOfRange
+
+	// NotFound is the type of errors that result from an entity that is not found
+	// or not accessible
+	NotFound
+
+	// Conflict is the type of errors that result from a conflict
+	Conflict
+
+	// AlreadyExists is the type of errors that result from a conflict where the
+	// updated/created entity already exists
+	AlreadyExists
+
+	// Unauthorized is the type of errors where the request is unauthorized where
+	// it should be
+	Unauthorized
+
+	// PermissionDenied is the type of errors where the request was authorized but
+	// did not grant access to the requested entity
+	PermissionDenied
+
+	// Timeout is the type of errors that are a result of a process taking too
+	// long to complete
+	Timeout
+
+	// NotImplemented is the type of errors that result from a requested action
+	// that is not (yet) implemented
+	NotImplemented
+
+	// TemporarilyUnavailable is the type of errors that result from a service
+	// being temporarily unavailable (down)
+	TemporarilyUnavailable
+
+	// PermanentlyUnavailable is the type of errors that result from an action
+	// that has been deprecated and is no longer available
+	PermanentlyUnavailable
+)

--- a/errors/type.go
+++ b/errors/type.go
@@ -1,5 +1,10 @@
 package errors
 
+import (
+	"fmt"
+	"strings"
+)
+
 type Type uint8
 
 const (
@@ -51,3 +56,44 @@ const (
 	// that has been deprecated and is no longer available
 	PermanentlyUnavailable
 )
+
+// string representations of the Types
+// keep up to date with the iota
+var str = []string{
+	"Unknown",
+	"Internal",
+	"Invalid argument",
+	"Out of range",
+	"Not found",
+	"Conflict",
+	"Already exists",
+	"Unauthorized",
+	"Permission denied",
+	"Timeout",
+	"Not implemented",
+	"Temporarily unavailable",
+	"Permanently unavailable",
+}
+
+// String implements stringer
+func (t Type) String() string {
+	return str[t]
+}
+
+// MarshalText implements TextMarsheler
+func (t Type) MarshalText() ([]byte, error) {
+	return []byte(t.String()), nil
+}
+
+// UnmarshalText implements TextUnmarsheler
+func (t *Type) UnmarshalText(text []byte) error {
+	enum := strings.ToLower(string(text))
+	for i, typ := range str {
+		if enum == strings.ToLower(typ) {
+			*t = Type(i)
+			return nil
+		}
+	}
+
+	return fmt.Errorf("Invalid event type")
+}

--- a/errors/type_test.go
+++ b/errors/type_test.go
@@ -1,0 +1,35 @@
+package errors
+
+import (
+	"testing"
+
+	"github.com/smartystreets/assertions"
+)
+
+func TestTypeString(t *testing.T) {
+	a := assertions.New(t)
+
+	a.So(Unknown.String(), assertions.ShouldEqual, "Unknown")
+	a.So(Timeout.String(), assertions.ShouldEqual, "Timeout")
+}
+
+func TestTypeMarshal(t *testing.T) {
+	a := assertions.New(t)
+
+	text, err := Unknown.MarshalText()
+	a.So(err, assertions.ShouldBeNil)
+	a.So(text, assertions.ShouldResemble, []byte("Unknown"))
+}
+
+func TestTypeUnmarshal(t *testing.T) {
+	a := assertions.New(t)
+
+	var typ Type
+	err := typ.UnmarshalText([]byte("Temporarily unavailable"))
+	a.So(err, assertions.ShouldBeNil)
+	a.So(typ, assertions.ShouldEqual, TemporarilyUnavailable)
+
+	err = typ.UnmarshalText([]byte("temporarily unavailable"))
+	a.So(err, assertions.ShouldBeNil)
+	a.So(typ, assertions.ShouldEqual, TemporarilyUnavailable)
+}


### PR DESCRIPTION
This pull request adds errors that are portable across different protocols (http, gRPC, ...) and that are localizable to a certain degree.

Every component (service, ...) that can create errors should define the error types it has using a descriptor. This descriptor can be used to create new errors of this type, which implement the builtin `error` interface.

On top of that helpers are included to convert errors from `error` into a more rich interface `Error` which has type info about the error.

The error types are also registered into an error registry which can be used to find more info about the types (like the localizable error format etc)