### PR TITLE
Feature/handier apex imports

### DIFF
--- a/log/apex/apex.go
+++ b/log/apex/apex.go
@@ -9,32 +9,45 @@ import (
 )
 
 // Stdout logging apex/log
-func Stdout() log.Interface {
+func Stdout() *apexInterfaceWrapper {
 	return Wrap(&apex.Logger{
 		Level:   apex.InfoLevel,
 		Handler: cli.New(os.Stdout),
 	})
 }
 
+const (
+	DebugLevel = apex.DebugLevel
+	InfoLevel  = apex.InfoLevel
+	WarnLevel  = apex.WarnLevel
+	ErrorLevel = apex.ErrorLevel
+	FatalLevel = apex.FatalLevel
+)
+
+var (
+	ParseLevel     = apex.ParseLevel
+	MustParseLevel = apex.MustParseLevel
+)
+
 // Wrap apex.Interface
-func Wrap(ctx apex.Interface) log.Interface {
+func Wrap(ctx *apex.Logger) *apexInterfaceWrapper {
 	return &apexInterfaceWrapper{ctx}
 }
 
 type apexInterfaceWrapper struct {
-	apex.Interface
+	*apex.Logger
 }
 
 func (w *apexInterfaceWrapper) WithField(k string, v interface{}) log.Interface {
-	return &apexEntryWrapper{w.Interface.WithField(k, v)}
+	return &apexEntryWrapper{w.Logger.WithField(k, v)}
 }
 
 func (w *apexInterfaceWrapper) WithFields(fields log.Fields) log.Interface {
-	return &apexEntryWrapper{w.Interface.WithFields(apex.Fields(fields))}
+	return &apexEntryWrapper{w.Logger.WithFields(apex.Fields(fields))}
 }
 
 func (w *apexInterfaceWrapper) WithError(err error) log.Interface {
-	return &apexEntryWrapper{w.Interface.WithError(err)}
+	return &apexEntryWrapper{w.Logger.WithError(err)}
 }
 
 type apexEntryWrapper struct {

--- a/log/apex/apex.go
+++ b/log/apex/apex.go
@@ -50,6 +50,17 @@ func (w *apexInterfaceWrapper) WithError(err error) log.Interface {
 	return &apexEntryWrapper{w.Logger.WithError(err)}
 }
 
+// MustParseLevel is a convience function that parses the passed in string
+// as a log level and sets the log level of the apexInterfaceWrapper to the
+// parsed level. If an error occurs it will handle it with w.Fatal
+func (w *apexInterfaceWrapper) MustParseLevel(s string) {
+	level, err := ParseLevel(s)
+	if err != nil {
+		w.WithError(err).WithField("level", s).Fatal("Could not parse log level")
+	}
+	w.Level = level
+}
+
 type apexEntryWrapper struct {
 	*apex.Entry
 }


### PR DESCRIPTION
Instead of 

```
import (
  "github.com/apex/log"
  "github.com/TheThingsNetwork/go-utils/log/apex"
  "github.com/TheThingsNetwork/go-utils/handlers/cli"
)

func main() {
  logger := &log.Logger{
    Level: log.DebugLevel,
    Handler: cli.New(os.Stdout),
  }

  ctx := apex.Wrap(logger)
  level, err :=  log.ParseLevel("warn")
  if err != nil {
    ctx.WithError(err).Fatal("Could not parse log level")
  }
  logger.Level = level
}
```

You can now just write
```
import   "github.com/TheThingsNetwork/go-utils/log/apex"

func main() {
  ctx := apex.Stdout()
  level, err :=  apex.ParseLevel("warn")
  if err != nil {
    ctx.WithError(err).Fatal("Could not parse log level")
  }
  ctx.Level = level
}
```

Or even:
```
import   "github.com/TheThingsNetwork/go-utils/log/apex"

func main() {
  ctx := apex.Stdout()
  ctx.MustParseLevel("warn")
}
```


Note that this PR has a breaking API change in the case where you pass something else than `log.Logger` to `apex.Wrap`.

