### PR TITLE
Implement sendbuffer package

### DIFF
--- a/grpc/sendbuffer/sendbuffer.go
+++ b/grpc/sendbuffer/sendbuffer.go
@@ -1,0 +1,96 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+// Package sendbuffer implements a buffered Client-Streaming RPC that drops the oldest messages on buffer overflow.
+package sendbuffer
+
+import (
+	"sync/atomic"
+
+	ttnlog "github.com/TheThingsNetwork/go-utils/log"
+	"github.com/golang/protobuf/ptypes/empty"
+	"google.golang.org/grpc"
+)
+
+var slack = 4
+
+// New returns a new Stream with the given buffer size and setup function.
+// If you start calling SendMsg() immediately after this, the stream will start buffering.
+// You must call Run() in a separate goroutine to actually start handling the stream.
+func New(bufferSize int, setup func() (grpc.ClientStream, error)) *Stream {
+	return &Stream{
+		setupFunc:  setup,
+		sendBuffer: make(chan interface{}, bufferSize+slack),
+		log:        ttnlog.Get(),
+	}
+}
+
+// Stream client->server streaming rpc that buffers (at most) the last {bufferSize} messages
+type Stream struct {
+	// BEGIN sync/atomic aligned
+	sent    uint64
+	dropped uint64
+	// END sync/atomic aligned
+
+	setupFunc  func() (grpc.ClientStream, error)
+	sendBuffer chan interface{}
+
+	log ttnlog.Interface
+}
+
+// Stats of the stream
+func (s *Stream) Stats() (sent, dropped uint64) {
+	return atomic.LoadUint64(&s.sent), atomic.LoadUint64(&s.dropped)
+}
+
+// SendMsg sends a message on the stream
+func (s *Stream) SendMsg(msg interface{}) {
+	if len(s.sendBuffer) > cap(s.sendBuffer)-slack {
+		atomic.AddUint64(&s.dropped, 1)
+		s.log.Debug("sendbuffer: dropping message")
+		<-s.sendBuffer
+	}
+	s.sendBuffer <- msg
+}
+
+// Run the stream
+func (s *Stream) Run() error {
+	stream, err := s.setupFunc()
+	if err != nil {
+		return err
+	}
+
+	recvErr := make(chan error)
+	defer func() {
+		go func() { // empty the recvErr channel on return
+			<-recvErr
+		}()
+	}()
+
+	go func() {
+		var e empty.Empty
+		err := stream.RecvMsg(&e)
+		s.log.WithError(err).Debug("sendbuffer: error from stream.RecvMsg")
+		recvErr <- err
+		close(recvErr)
+	}()
+
+	defer stream.CloseSend()
+
+	for {
+		select {
+		case err := <-recvErr:
+			return err
+		case <-stream.Context().Done():
+			s.log.WithError(stream.Context().Err()).Debug("sendbuffer: context done")
+			return stream.Context().Err()
+		case msg := <-s.sendBuffer:
+			if err = stream.SendMsg(msg); err != nil {
+				s.log.WithError(err).Debug("sendbuffer: error from stream.SendMsg")
+				return err
+			}
+			s.log.Debug("sendbuffer: sent message")
+			atomic.AddUint64(&s.sent, 1)
+		}
+	}
+}

--- a/grpc/sendbuffer/sendbuffer_test.go
+++ b/grpc/sendbuffer/sendbuffer_test.go
@@ -1,0 +1,122 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package sendbuffer_test
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	. "github.com/TheThingsNetwork/go-utils/grpc/internal/test"
+	"github.com/TheThingsNetwork/go-utils/grpc/sendbuffer"
+	s "github.com/smartystreets/assertions"
+	"google.golang.org/grpc"
+)
+
+const sleepTime = 20 * time.Millisecond
+
+var (
+	opts              []grpc.DialOption
+	addr              string
+	errIsNotRetryable bool
+	backoffTime       time.Duration
+)
+
+func Example() {
+	// Set up gRPC as usual
+	conn, err := grpc.Dial(addr, opts...)
+	if err != nil {
+		panic(err)
+	}
+	testClient := NewTestClient(conn)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pushBuffer := sendbuffer.New(5, func() (grpc.ClientStream, error) {
+		// maybe extend the context?
+		return testClient.Push(ctx)
+	})
+
+	// From now on the pushBuffer starts buffering
+	pushBuffer.SendMsg(&Foo{})
+
+	// The Run func actually starts flushing the buffer out to the stream
+	errCh := make(chan error)
+	go func() {
+		for {
+			err := pushBuffer.Run()
+			if err == nil || err == context.Canceled || errIsNotRetryable {
+				errCh <- err
+				close(errCh)
+				return
+			}
+			time.Sleep(backoffTime)
+		}
+	}()
+
+	// Just keep sending those messages
+	pushBuffer.SendMsg(&Foo{})
+}
+
+func TestSendBuffer(t *testing.T) {
+	a := s.New(t)
+
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		panic(err)
+	}
+
+	server := NewTestServer()
+	rpc := grpc.NewServer()
+	RegisterTestServer(rpc, server)
+	go func() {
+		if err := rpc.Serve(lis); err != nil {
+			panic(err)
+		}
+	}()
+
+	conn, err := grpc.Dial(lis.Addr().String(), grpc.WithInsecure())
+	if err != nil {
+		panic(err)
+	}
+	cli := NewTestClient(conn)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var setupCalled bool
+	buf := sendbuffer.New(5, func() (grpc.ClientStream, error) {
+		setupCalled = true
+		return cli.Push(ctx)
+	})
+
+	var runReturned bool
+	var runErr error
+	go func() {
+		if err := buf.Run(); err != nil {
+			runReturned = true
+			runErr = err
+		}
+	}()
+
+	time.Sleep(sleepTime)
+	a.So(setupCalled, s.ShouldBeTrue)
+
+	buf.SendMsg(&Foo{Foo: "foo"})
+
+	time.Sleep(sleepTime)
+	a.So(server.PushFoo, s.ShouldNotBeNil)
+	a.So(server.PushFoo.Foo, s.ShouldEqual, "foo")
+
+	cancel()
+
+	time.Sleep(sleepTime)
+	a.So(runReturned, s.ShouldBeTrue)
+	a.So(runErr, s.ShouldEqual, context.Canceled)
+
+	sent, dropped := buf.Stats()
+	a.So(sent, s.ShouldEqual, 1)
+	a.So(dropped, s.ShouldEqual, 0)
+}


### PR DESCRIPTION
The `sendbuffer` package wraps a grpc ClientStream so that it

- allows sending (buffering) before the stream is actually started
- discards the oldest (instead of the newest) messages if the buffer is full
- allows sending from concurrent goroutines (the regular SendMsg is not goroutine-safe)