### PR TITLE
Influx.BatchingWriter: limit instances spawned, docs, tests

### DIFF
--- a/influx/writer.go
+++ b/influx/writer.go
@@ -187,12 +187,19 @@ func WithInstanceLimit(v uint) BatchingWriterOption {
 	}
 }
 
-// NewBatchingWriter creates new BatchingWriter.
-func NewBatchingWriter(log ttnlog.Interface, w BatchPointsWriter, scalingInterval time.Duration, opts ...BatchingWriterOption) *BatchingWriter {
+// WithInstanceLimit sets a limit on amount of additional instances spawned by BatchingWriter
+func WithScalingInterval(v time.Duration) BatchingWriterOption {
+	return func(w *BatchingWriter) {
+		w.scalingInterval = v
+	}
+}
+
+// NewBatchingWriter creates new BatchingWriter. If WithScalingInterval is not specified, DefaultScalingInterval value is used.
+func NewBatchingWriter(log ttnlog.Interface, w BatchPointsWriter, opts ...BatchingWriterOption) *BatchingWriter {
 	bw := &BatchingWriter{
 		log:             log,
 		writer:          w,
-		scalingInterval: scalingInterval,
+		scalingInterval: DefaultScalingInterval,
 		pointChans:      make(map[influxdb.BatchPointsConfig]chan *batchPoint),
 	}
 	bw.spawnAdditional = bw.spawnAdditionalWithoutCheck

--- a/influx/writer.go
+++ b/influx/writer.go
@@ -114,8 +114,8 @@ func writeInBatches(log ttnlog.Interface, w BatchPointsWriter, bpConf influxdb.B
 // BatchingWriter is a PointWriter, which writes points in batches.
 // BatchingWriter scales automatically once it notices a delay of scalingInterval to write a batch of points and downscales if no points are supplied to an instance for a duration of scalingInterval.
 // BatchingWriter spawns an instance for each unique BatchPointsConfig specified and up to limit additional instances on top of that.
-// BatchingWriter does not limit the amount of instances if limit is set to 0. (There should be at least one instance)
-// Each instance of the writer is spawned in a separate goroutine.
+// BatchingWriter does not limit the amount of instances if limit is nil.
+// Each instance is spawned in a separate goroutine.
 type BatchingWriter struct {
 	log             ttnlog.Interface
 	writer          BatchPointsWriter

--- a/influx/writer.go
+++ b/influx/writer.go
@@ -157,12 +157,16 @@ func NewBatchingWriter(log ttnlog.Interface, w BatchPointsWriter, opts ...Batchi
 		log:             log,
 		writer:          w,
 		scalingInterval: DefaultScalingInterval,
+		limit:           DefaultInstanceLimit,
 		pointChans:      make(map[influxdb.BatchPointsConfig]chan *batchPoint),
 	}
 	for _, opt := range opts {
 		opt(bw)
 	}
-	bw.log = bw.log.WithField("limit", bw.limit)
+	bw.log = bw.log.WithFields(ttnlog.Fields{
+		"limit":           bw.limit,
+		"scalingInterval": bw.scalingInterval,
+	})
 	return bw
 }
 

--- a/influx/writer.go
+++ b/influx/writer.go
@@ -5,6 +5,7 @@ package influx
 
 import (
 	"fmt"
+	"runtime"
 	"sync"
 	"time"
 
@@ -16,7 +17,7 @@ import (
 const DefaultScalingInterval = 500 * time.Millisecond
 
 // DefaultInstanceLimit represents default limit on instances spawned by BatchingWriter.
-const DefaultInstanceLimit = 5
+var DefaultInstanceLimit = uint(runtime.NumCPU())
 
 // newBatchPoints creates new influxdb.BatchPoints with specified bpConf.
 // Panics on errors.

--- a/influx/writer.go
+++ b/influx/writer.go
@@ -16,7 +16,7 @@ import (
 const DefaultScalingInterval = 500 * time.Millisecond
 
 // DefaultInstanceLimit represents default limit on instances spawned by BatchingWriter.
-const DefaultInstanceLimit = 100
+const DefaultInstanceLimit = 5
 
 // newBatchPoints creates new influxdb.BatchPoints with specified bpConf.
 // Panics on errors.

--- a/influx/writer.go
+++ b/influx/writer.go
@@ -75,8 +75,6 @@ func writeInBatches(log ttnlog.Interface, w BatchPointsWriter, bpConf influxdb.B
 	log = log.WithField("config", bpConf)
 	log.Info("Batching writer instance created")
 
-	waitTime := scalingInterval
-
 	var points []*batchPoint
 	for {
 		select {
@@ -88,7 +86,7 @@ func writeInBatches(log ttnlog.Interface, w BatchPointsWriter, bpConf influxdb.B
 				case p := <-ch:
 					points = append(points, p)
 					continue
-				case <-time.After(waitTime):
+				case <-time.After(scalingInterval):
 					if !keepalive {
 						log.Info("Removing batching writer instance")
 						return

--- a/influx/writer_test.go
+++ b/influx/writer_test.go
@@ -64,18 +64,12 @@ const (
 
 func TestBatchWriter(t *testing.T) {
 	a := s.New(t)
-	for _, mw := range []int{
-		-1, 0, 100,
+	for _, mw := range []uint{
+		0, 1, 100,
 	} {
 		mock := newMockBatchPointWriter(a)
 
-		var w *BatchingWriter
-		if mw < 0 {
-			w = NewBatchingWriter(ttnlog.Get(), mock, WithScalingInterval(ScalingInterval))
-		} else {
-			w = NewBatchingWriter(ttnlog.Get(), mock, WithScalingInterval(ScalingInterval), WithInstanceLimit(uint(mw)))
-			a.So(w.limit, s.ShouldEqual, mw)
-		}
+		w := NewBatchingWriter(ttnlog.Get(), mock, WithScalingInterval(ScalingInterval), WithInstanceLimit(uint(mw)))
 
 		checkCh := make(chan struct{})
 

--- a/influx/writer_test.go
+++ b/influx/writer_test.go
@@ -71,9 +71,9 @@ func TestBatchWriter(t *testing.T) {
 
 		var w *BatchingWriter
 		if mw < 0 {
-			w = NewBatchingWriter(ttnlog.Get(), mock, ScalingInterval)
+			w = NewBatchingWriter(ttnlog.Get(), mock, WithScalingInterval(ScalingInterval))
 		} else {
-			w = NewBatchingWriter(ttnlog.Get(), mock, ScalingInterval, WithInstanceLimit(uint(mw)))
+			w = NewBatchingWriter(ttnlog.Get(), mock, WithScalingInterval(ScalingInterval), WithInstanceLimit(uint(mw)))
 			a.So(w.limit, s.ShouldEqual, mw)
 		}
 


### PR DESCRIPTION
Made constructors return concrete types instead of interfaces for easier testing and to be more idiomatic. Added docs.