### PR TITLE
Feature/portable errors

### DIFF
--- a/errors/cause.go
+++ b/errors/cause.go
@@ -1,0 +1,32 @@
+package errors
+
+import "errors"
+
+const causeKey = "cause"
+
+// Causer is the type of errors that can have a cause
+type Causer interface {
+	Cause() error
+}
+
+// Cause returns the cause of an error
+func Cause(err Error) error {
+	attributes := err.Attributes()
+	if attributes == nil {
+		return nil
+	}
+
+	cause, ok := attributes[causeKey]
+	if !ok {
+		return nil
+	}
+
+	switch v := cause.(type) {
+	case error:
+		return v
+	case string:
+		return errors.New(v)
+	default:
+		return nil
+	}
+}

--- a/errors/cause.go
+++ b/errors/cause.go
@@ -1,3 +1,6 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
 package errors
 
 import "errors"

--- a/errors/code.go
+++ b/errors/code.go
@@ -8,6 +8,12 @@ import (
 	"strconv"
 )
 
+// Code represents a unique error code
+type Code uint32
+
+// NoCode is a missing code
+const NoCode Code = 0
+
 // String implmenents stringer
 func (c Code) String() string {
 	return fmt.Sprintf("%v", uint32(c))
@@ -20,4 +26,30 @@ func parseCode(str string) Code {
 		return Code(0)
 	}
 	return Code(code)
+}
+
+// Range is a utility function that creates a code builder.
+//
+// Example:
+//	var code = Range(1000, 2000)
+//  var ErrSomethingWasWrong := &ErrDescriptor{
+//		// ...
+//		Code: code(77),
+//  }
+//
+// This can be used to create disjunct code ranges and be strict about it.
+// The codes created by the returned function will range from start (inclusive)
+// to end (exclusive) or the function will panic otherwise.
+func Range(start uint32, end uint32) func(uint32) Code {
+	if end <= start {
+		panic("Range end <= start")
+	}
+
+	return func(i uint32) Code {
+		if i >= (end - start) {
+			panic(fmt.Sprintf("Code %v does not fit in range [%v, %v[", i, start, end))
+		}
+
+		return Code(start + i)
+	}
 }

--- a/errors/code.go
+++ b/errors/code.go
@@ -1,0 +1,20 @@
+package errors
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// String implmenents stringer
+func (c Code) String() string {
+	return fmt.Sprintf("%v", uint32(c))
+}
+
+// pareCode parses a string into a Code or returns 0 if the parse failed
+func parseCode(str string) Code {
+	code, err := strconv.Atoi(str)
+	if err != nil {
+		return Code(0)
+	}
+	return Code(code)
+}

--- a/errors/code.go
+++ b/errors/code.go
@@ -1,3 +1,6 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
 package errors
 
 import (

--- a/errors/code_test.go
+++ b/errors/code_test.go
@@ -1,3 +1,6 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
 package errors
 
 import (

--- a/errors/code_test.go
+++ b/errors/code_test.go
@@ -1,0 +1,19 @@
+package errors
+
+import (
+	"testing"
+
+	"github.com/smartystreets/assertions"
+)
+
+func TestRange(t *testing.T) {
+	a := assertions.New(t)
+	code := Range(1000, 2000)
+
+	a.So(code(0), assertions.ShouldEqual, 1000)
+	a.So(code(1), assertions.ShouldEqual, 1001)
+
+	a.So(func() { code(1000) }, assertions.ShouldPanic)
+	a.So(func() { code(1001) }, assertions.ShouldPanic)
+	a.So(func() { _ = Range(2, 1) }, assertions.ShouldPanic)
+}

--- a/errors/descriptor.go
+++ b/errors/descriptor.go
@@ -38,7 +38,7 @@ func (err *ErrDescriptor) New(attributes Attributes) Error {
 	}
 
 	return &impl{
-		message:    Format(err.MessageFormat, attributes, defaultValueFormatter),
+		message:    Format(err.MessageFormat, attributes),
 		code:       err.Code,
 		typ:        err.Type,
 		attributes: attributes,

--- a/errors/descriptor.go
+++ b/errors/descriptor.go
@@ -1,3 +1,6 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
 package errors
 
 import "fmt"

--- a/errors/descriptor.go
+++ b/errors/descriptor.go
@@ -36,7 +36,7 @@ type ErrDescriptor struct {
 
 // New creates a new error based on the error descriptor
 func (err *ErrDescriptor) New(attributes Attributes) Error {
-	if err.Code != 0 && !err.registered {
+	if err.Code != NoCode && !err.registered {
 		panic(fmt.Errorf("Error descriptor with code %v was not registered", err.Code))
 	}
 

--- a/errors/descriptor.go
+++ b/errors/descriptor.go
@@ -33,15 +33,15 @@ type ErrDescriptor struct {
 
 // Format formats the attributes into an Error
 func (err *ErrDescriptor) New(attributes Attributes) Error {
-	if !err.registered {
+	if err.Code != 0 && !err.registered {
 		panic(fmt.Errorf("Error descriptor with code %v was not registered", err.Code))
 	}
 
 	return &impl{
-		message:    Format(err.MessageFormat, attributes),
-		code:       err.Code,
-		typ:        err.Type,
-		attributes: attributes,
+		Imessage:    Format(err.MessageFormat, attributes),
+		Icode:       err.Code,
+		Ityp:        err.Type,
+		Iattributes: attributes,
 	}
 }
 

--- a/errors/descriptor.go
+++ b/errors/descriptor.go
@@ -1,0 +1,56 @@
+package errors
+
+import "fmt"
+
+// ErrDescriptor is a helper struct to easily build new Errors from and to be
+// the authoritive information about error codes.
+//
+// The descriptor can be used to find out information about the error after it
+// has been handed over between components
+type ErrDescriptor struct {
+	// MessageFormat is the format of the error message. Attributes will be filled
+	// in when an error is created using New(). For example:
+	//
+	//   "This is an error about user {username}"
+	//
+	// when passed an atrtributes map with "username" set to "john" would interpolate to
+	//
+	//   "This is an error about user john"
+	//
+	// The idea about this message format is that is is localizable
+	MessageFormat string
+
+	// Code is the code of errors that are created by this descriptor
+	Code Code
+
+	// Type is the type of errors created by this descriptor
+	Type Type
+
+	// registered denotes wether or not the error has been registered
+	// (by a call to Register)
+	registered bool
+}
+
+// Format formats the attributes into an Error
+func (err *ErrDescriptor) New(attributes Attributes) Error {
+	if !err.registered {
+		panic(fmt.Errorf("Error descriptor with code %v was not registered", err.Code))
+	}
+
+	return &impl{
+		message:    Format(err.MessageFormat, attributes, defaultValueFormatter),
+		code:       err.Code,
+		typ:        err.Type,
+		attributes: attributes,
+	}
+}
+
+// New creates a new Error from a descriptor and some attributes
+func New(descriptor *ErrDescriptor, attributes Attributes) Error {
+	return descriptor.New(attributes)
+}
+
+// Register registers the descriptor
+func (err *ErrDescriptor) Register() {
+	Register(err)
+}

--- a/errors/descriptor.go
+++ b/errors/descriptor.go
@@ -34,7 +34,7 @@ type ErrDescriptor struct {
 	registered bool
 }
 
-// Format formats the attributes into an Error
+// New creates a new error based on the error descriptor
 func (err *ErrDescriptor) New(attributes Attributes) Error {
 	if err.Code != 0 && !err.registered {
 		panic(fmt.Errorf("Error descriptor with code %v was not registered", err.Code))

--- a/errors/descriptor.go
+++ b/errors/descriptor.go
@@ -41,10 +41,10 @@ func (err *ErrDescriptor) New(attributes Attributes) Error {
 	}
 
 	return &impl{
-		Imessage:    Format(err.MessageFormat, attributes),
-		Icode:       err.Code,
-		Ityp:        err.Type,
-		Iattributes: attributes,
+		message:    Format(err.MessageFormat, attributes),
+		code:       err.Code,
+		typ:        err.Type,
+		attributes: attributes,
 	}
 }
 

--- a/errors/descriptor_test.go
+++ b/errors/descriptor_test.go
@@ -14,7 +14,7 @@ func TestDescriptor(t *testing.T) {
 
 	d := &ErrDescriptor{
 		MessageFormat: "You do not have access to app with id {app_id}",
-		Code:          77,
+		Code:          code(77),
 		Type:          PermissionDenied,
 		registered:    true,
 	}

--- a/errors/descriptor_test.go
+++ b/errors/descriptor_test.go
@@ -1,3 +1,6 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
 package errors
 
 import (

--- a/errors/descriptor_test.go
+++ b/errors/descriptor_test.go
@@ -1,0 +1,28 @@
+package errors
+
+import (
+	"testing"
+
+	"github.com/smartystreets/assertions"
+)
+
+func TestDescriptor(t *testing.T) {
+	a := assertions.New(t)
+
+	d := &ErrDescriptor{
+		MessageFormat: "You do not have access to app with id {app_id}",
+		Code:          77,
+		Type:          PermissionDenied,
+		registered:    true,
+	}
+
+	attributes := Attributes{
+		"app_id": "foo",
+	}
+	err := New(d, attributes)
+
+	a.So(err.Error(), assertions.ShouldEqual, "You do not have access to app with id foo")
+	a.So(err.Code(), assertions.ShouldEqual, d.Code)
+	a.So(err.Type(), assertions.ShouldEqual, d.Type)
+	a.So(err.Attributes(), assertions.ShouldResemble, attributes)
+}

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,6 +1,6 @@
 package errors
 
-// Error is the interface og grpc errors
+// Error is the interface of portable errors
 type Error interface {
 	error
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,3 +1,6 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
 package errors
 
 // Error is the interface of portable errors

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,0 +1,22 @@
+package errors
+
+// Error is the interface og grpc errors
+type Error interface {
+	// Error returns the formatted error message
+	Error() string
+
+	// Code returns the error code
+	Code() Code
+
+	// Type returns the error type
+	Type() Type
+
+	// Attributes returns the error attributes
+	Attributes() Attributes
+}
+
+// Code represents a unique error code
+type Code uint32
+
+// Attributes
+type Attributes map[string]interface{}

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -2,8 +2,7 @@ package errors
 
 // Error is the interface og grpc errors
 type Error interface {
-	// Error returns the formatted error message
-	Error() string
+	error
 
 	// Code returns the error code
 	Code() Code

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -20,5 +20,5 @@ type Error interface {
 // Code represents a unique error code
 type Code uint32
 
-// Attributes
+// Attributes is a map of attributes
 type Attributes map[string]interface{}

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -17,8 +17,5 @@ type Error interface {
 	Attributes() Attributes
 }
 
-// Code represents a unique error code
-type Code uint32
-
 // Attributes is a map of attributes
 type Attributes map[string]interface{}

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,6 +1,22 @@
 // Copyright © 2017 The Things Network
 // Use of this source code is governed by the MIT license that can be found in the LICENSE file.
 
+// Package errors implements a common interface for errors to be communicated
+// within and between components of a multi-service architecture.
+//
+// It relies on the concept of describing your errors statically and then
+// building actual instances of the errors when they occur.
+//
+// The resulting errors are uniquely identifiable so their orginal descriptions
+// can be retreived. This makes it easier to localize the error messages since
+// we can enumerate all possible errors.
+//
+// There's only one restriction: all services that use error descriptors must
+// ensure that their Codes are unique.
+// This is really a cross-service restriction that cannot be enforced by the
+// package itself so some hygiene and discpline is required here.
+// To aid with this, use the Range function
+// to create a code range that is disjunct from other ranges.
 package errors
 
 // Error is the interface of portable errors

--- a/errors/example_test.go
+++ b/errors/example_test.go
@@ -7,6 +7,9 @@ import "fmt"
 
 func Example() {
 
+	// define the range your error codes should be in
+	code := Range(10000, 120000)
+
 	// ErrSomeUserMistake is the description of the error some user made
 	// that costs the company some money
 	ErrSomeUserMistake := &ErrDescriptor{
@@ -20,7 +23,7 @@ func Example() {
 		Type: InvalidArgument,
 
 		// Code is the unique code of this error
-		Code: 391,
+		Code: code(391),
 	}
 
 	// register the error so others can find it based on Code

--- a/errors/example_test.go
+++ b/errors/example_test.go
@@ -1,3 +1,6 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
 package errors
 
 import "fmt"

--- a/errors/example_test.go
+++ b/errors/example_test.go
@@ -1,0 +1,37 @@
+package errors
+
+import "fmt"
+
+func Example() {
+
+	// ErrSomeUserMistake is the description of the error some user made
+	// that costs the company some money
+	ErrSomeUserMistake := &ErrDescriptor{
+		// MessageFormat is the format the error message will be using
+		// It is written in ICU message format
+		MessageFormat: "You made a mistake cost us {price, plural, =0 {no money} =1 {one dollar} other {{price} dollars}}",
+
+		// Type is the general category of the error (like HTTP status codes it puts
+		// the error in a category that clients can understand without knowing the
+		// error).
+		Type: InvalidArgument,
+
+		// Code is the unique code of this error
+		Code: 391,
+	}
+
+	// register the error so others can find it based on Code
+	ErrSomeUserMistake.Register()
+
+	// Create a new error based on the descriptor
+	err := ErrSomeUserMistake.New(Attributes{
+		"price": 7,
+	})
+
+	// this will print the formatted error message
+	fmt.Println(err)
+	// Output: You made a mistake cost us 7 dollars
+
+	// You can get the error descriptor back based on any error
+	_ = Descriptor(err)
+}

--- a/errors/format.go
+++ b/errors/format.go
@@ -1,0 +1,27 @@
+package errors
+
+import (
+	"fmt"
+	"regexp"
+)
+
+type ValueFormatter func(interface{}) string
+
+func defaultValueFormatter(v interface{}) string {
+	return fmt.Sprintf("%v", v)
+}
+
+// re finds names in the format string
+var re = regexp.MustCompile("{(.+?)}")
+
+// Format formats the values into the provided string
+func Format(format string, values Attributes, formatValue ValueFormatter) string {
+	return re.ReplaceAllStringFunc(format, func(name string) string {
+		if values == nil {
+			return "<nil>"
+		}
+
+		stripped := name[1 : len(name)-1]
+		return formatValue(values[stripped])
+	})
+}

--- a/errors/format.go
+++ b/errors/format.go
@@ -2,26 +2,63 @@ package errors
 
 import (
 	"fmt"
-	"regexp"
+	"reflect"
+
+	"github.com/gotnospirit/messageformat"
 )
 
-type ValueFormatter func(interface{}) string
+// Format formats the values into the provided string
+func Format(format string, values Attributes) string {
+	formatter, err := messageformat.New()
+	if err != nil {
+		return format
+	}
 
-func defaultValueFormatter(v interface{}) string {
-	return fmt.Sprintf("%v", v)
+	fm, err := formatter.Parse(format)
+	if err != nil {
+		return format
+	}
+
+	fixed := make(map[string]interface{}, len(values))
+	for k, v := range values {
+		fixed[k] = fix(v)
+	}
+
+	// todo format unsupported types
+	res, err := fm.FormatMap(fixed)
+	if err != nil {
+		fmt.Println("err", err)
+		return format
+	}
+
+	return res
 }
 
-// re finds names in the format string
-var re = regexp.MustCompile("{(.+?)}")
+// Fix coerces types that cannot be formatted by messageformat to string
+func fix(v interface{}) interface{} {
+	if v == nil {
+		return "<nil>"
+	}
 
-// Format formats the values into the provided string
-func Format(format string, values Attributes, formatValue ValueFormatter) string {
-	return re.ReplaceAllStringFunc(format, func(name string) string {
-		if values == nil {
-			return "<nil>"
-		}
-
-		stripped := name[1 : len(name)-1]
-		return formatValue(values[stripped])
-	})
+	switch reflect.TypeOf(v).Kind() {
+	case reflect.Bool:
+	case reflect.Int:
+	case reflect.Int8:
+	case reflect.Int16:
+	case reflect.Int32:
+	case reflect.Int64:
+	case reflect.Uint:
+	case reflect.Uint8:
+	case reflect.Uint16:
+	case reflect.Uint32:
+	case reflect.Uint64:
+	case reflect.Uintptr:
+	case reflect.Float32:
+	case reflect.Float64:
+		return v
+	case reflect.Ptr:
+		// dereference and fix
+		return fix(reflect.ValueOf(v).Elem())
+	}
+	return fmt.Sprintf("%v", v)
 }

--- a/errors/format.go
+++ b/errors/format.go
@@ -1,3 +1,6 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
 package errors
 
 import (

--- a/errors/format_test.go
+++ b/errors/format_test.go
@@ -1,0 +1,22 @@
+package errors
+
+import (
+	"testing"
+
+	"github.com/smartystreets/assertions"
+)
+
+func TestFormat(t *testing.T) {
+	a := assertions.New(t)
+
+	format := "{foo} - {bar} - {nil} - {list} - {map}"
+	{
+		res := Format(format, Attributes{
+			"foo":  10,
+			"bar":  "bar",
+			"list": []int{1, 2, 3},
+			"map":  map[string]int{"ok": 1},
+		}, defaultValueFormatter)
+		a.So(res, assertions.ShouldEqual, "10 - bar - <nil> - [1 2 3] - map[ok:1]")
+	}
+}

--- a/errors/format_test.go
+++ b/errors/format_test.go
@@ -6,17 +6,39 @@ import (
 	"github.com/smartystreets/assertions"
 )
 
+func TestFormatTypes(t *testing.T) {
+	a := assertions.New(t)
+
+	format := "{foo} - {bar} - {nil} - {list} - {map} - {complex} - {ptr}"
+	{
+		val := 10
+		res := Format(format, Attributes{
+			"foo":     10,
+			"bar":     "bar",
+			"nil":     nil,
+			"list":    []int{1, 2, 3},
+			"map":     map[string]int{"ok": 1},
+			"complex": 3 + 4i,
+			"ptr":     &val,
+		})
+		a.So(res, assertions.ShouldEqual, "10 - bar - <nil> - [1 2 3] - map[ok:1] - (3+4i) - 10")
+	}
+}
+
 func TestFormat(t *testing.T) {
 	a := assertions.New(t)
 
-	format := "{foo} - {bar} - {nil} - {list} - {map}"
+	format := "Found {foo, plural, =0 {no foos} =1 {# foo} other {# foos}}"
 	{
 		res := Format(format, Attributes{
-			"foo":  10,
-			"bar":  "bar",
-			"list": []int{1, 2, 3},
-			"map":  map[string]int{"ok": 1},
-		}, defaultValueFormatter)
-		a.So(res, assertions.ShouldEqual, "10 - bar - <nil> - [1 2 3] - map[ok:1]")
+			"foo": 1,
+		})
+		a.So(res, assertions.ShouldEqual, "Found 1 foo")
+	}
+	{
+		res := Format(format, Attributes{
+			"foo": 0,
+		})
+		a.So(res, assertions.ShouldEqual, "Found no foos")
 	}
 }

--- a/errors/format_test.go
+++ b/errors/format_test.go
@@ -1,3 +1,6 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
 package errors
 
 import (

--- a/errors/grpc.go
+++ b/errors/grpc.go
@@ -95,9 +95,9 @@ var format = "%s (e:%v) attributes = %s"
 // FromGRPC parses a gRPC error and returns an Error
 func FromGRPC(in error) Error {
 	out := &impl{
-		Imessage: grpc.ErrorDesc(in),
-		Ityp:     GRPCCodeToType(grpc.Code(in)),
-		Icode:    Code(0),
+		message: grpc.ErrorDesc(in),
+		typ:     GRPCCodeToType(grpc.Code(in)),
+		code:    Code(0),
 	}
 
 	matches := regex.FindStringSubmatch(in.Error())
@@ -106,18 +106,17 @@ func FromGRPC(in error) Error {
 		return out
 	}
 
-	// set message
-	out.Imessage = matches[1]
-	out.Icode = parseCode(matches[2])
-	_ = json.Unmarshal([]byte(matches[3]), &out.Iattributes)
+	out.message = matches[1]
+	out.code = parseCode(matches[2])
+	_ = json.Unmarshal([]byte(matches[3]), &out.attributes)
 
-	got := Get(Code(out.Icode))
+	got := Get(Code(out.code))
 	if got == nil {
 		return out
 	}
 
 	// Todo: find attributes
-	return got.New(out.Iattributes)
+	return got.New(out.attributes)
 }
 
 // ToGRPC turns an error into a gRPC error

--- a/errors/grpc.go
+++ b/errors/grpc.go
@@ -1,14 +1,79 @@
 package errors
 
 import (
+	"encoding/json"
+	"regexp"
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 )
 
 // GRPCCode returns the corresponding http status code from an error type
 func (t Type) GRPCCode() codes.Code {
-	// TODO
+	switch t {
+	case InvalidArgument:
+		return codes.InvalidArgument
+	case OutOfRange:
+		return codes.OutOfRange
+	case NotFound:
+		return codes.NotFound
+	case Conflict:
+	case AlreadyExists:
+		return codes.AlreadyExists
+	case Unauthorized:
+		return codes.Unauthenticated
+	case PermissionDenied:
+		return codes.PermissionDenied
+	case Timeout:
+		return codes.DeadlineExceeded
+	case NotImplemented:
+		return codes.Unimplemented
+	case TemporarilyUnavailable:
+		return codes.Unavailable
+	case PermanentlyUnavailable:
+		return codes.FailedPrecondition
+	case Canceled:
+		return codes.Canceled
+	case ResourceExhausted:
+		return codes.ResourceExhausted
+	case Internal:
+	case Unknown:
+		return codes.Unknown
+	}
+
 	return codes.Unknown
+}
+
+func GRPCCodeToType(code codes.Code) Type {
+	switch code {
+	case codes.InvalidArgument:
+		return InvalidArgument
+	case codes.OutOfRange:
+		return OutOfRange
+	case codes.NotFound:
+		return NotFound
+	case codes.AlreadyExists:
+		return AlreadyExists
+	case codes.Unauthenticated:
+		return Unauthorized
+	case codes.PermissionDenied:
+		return PermissionDenied
+	case codes.DeadlineExceeded:
+		return Timeout
+	case codes.Unimplemented:
+		return NotImplemented
+	case codes.Unavailable:
+		return TemporarilyUnavailable
+	case codes.FailedPrecondition:
+		return PermanentlyUnavailable
+	case codes.Canceled:
+		return Canceled
+	case codes.ResourceExhausted:
+		return ResourceExhausted
+	case codes.Unknown:
+		return Unknown
+	}
+	return Unknown
 }
 
 // GRPCCode returns the corresponding http status code from an error
@@ -19,4 +84,45 @@ func GRPCCode(err error) codes.Code {
 	}
 
 	return grpc.Code(err)
+}
+
+var regex = regexp.MustCompile(`.*desc = (.*) \(e:(\d+)\) attributes = (.*)`)
+var format = "%s (e:%v) attributes = %s"
+
+// FromGRPC parses a gRPC error and returns an Error
+func FromGRPC(in error) Error {
+	out := &impl{
+		Imessage: grpc.ErrorDesc(in),
+		Ityp:     GRPCCodeToType(grpc.Code(in)),
+		Icode:    Code(0),
+	}
+
+	matches := regex.FindStringSubmatch(in.Error())
+
+	if len(matches) < 4 {
+		return out
+	}
+
+	// set message
+	out.Imessage = matches[1]
+	out.Icode = parseCode(matches[2])
+	_ = json.Unmarshal([]byte(matches[3]), &out.Iattributes)
+
+	got := Get(Code(out.Icode))
+	if got == nil {
+		return out
+	}
+
+	// Todo: find attributes
+	return got.New(out.Iattributes)
+}
+
+// ToGRPC turns an error into a gRPC error
+func ToGRPC(in error) error {
+	if err, ok := in.(Error); ok {
+		attrs, _ := json.Marshal(err.Attributes())
+		return grpc.Errorf(err.Type().GRPCCode(), format, err.Error(), err.Code(), attrs)
+	}
+
+	return grpc.Errorf(codes.Unknown, in.Error())
 }

--- a/errors/grpc.go
+++ b/errors/grpc.go
@@ -91,7 +91,7 @@ func GRPCCode(err error) codes.Code {
 	return grpc.Code(err)
 }
 
-var grpcMessageFormat = regexp.MustCompile(`.*desc = (.*) \(e:(\d+)\) attributes = (.*)`)
+var grpcMessageFormat = regexp.MustCompile(`.*desc = (.*) \(e:(.+)\) attributes = (.*)`)
 var format = "%s (e:%v) attributes = %s"
 
 // FromGRPC parses a gRPC error and returns an Error
@@ -99,7 +99,7 @@ func FromGRPC(in error) Error {
 	out := &impl{
 		message: grpc.ErrorDesc(in),
 		typ:     GRPCCodeToType(grpc.Code(in)),
-		code:    Code(0),
+		code:    NoCode,
 	}
 
 	matches := grpcMessageFormat.FindStringSubmatch(in.Error())

--- a/errors/grpc.go
+++ b/errors/grpc.go
@@ -117,7 +117,6 @@ func FromGRPC(in error) Error {
 		return out
 	}
 
-	// Todo: find attributes
 	return got.New(out.attributes)
 }
 

--- a/errors/grpc.go
+++ b/errors/grpc.go
@@ -1,3 +1,6 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
 package errors
 
 import (

--- a/errors/grpc.go
+++ b/errors/grpc.go
@@ -91,7 +91,7 @@ func GRPCCode(err error) codes.Code {
 	return grpc.Code(err)
 }
 
-var regex = regexp.MustCompile(`.*desc = (.*) \(e:(\d+)\) attributes = (.*)`)
+var grpcMessageFormat = regexp.MustCompile(`.*desc = (.*) \(e:(\d+)\) attributes = (.*)`)
 var format = "%s (e:%v) attributes = %s"
 
 // FromGRPC parses a gRPC error and returns an Error
@@ -102,7 +102,7 @@ func FromGRPC(in error) Error {
 		code:    Code(0),
 	}
 
-	matches := regex.FindStringSubmatch(in.Error())
+	matches := grpcMessageFormat.FindStringSubmatch(in.Error())
 
 	if len(matches) < 4 {
 		return out

--- a/errors/grpc.go
+++ b/errors/grpc.go
@@ -1,0 +1,22 @@
+package errors
+
+import (
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+)
+
+// GRPCCode returns the corresponding http status code from an error type
+func (t Type) GRPCCode() codes.Code {
+	// TODO
+	return codes.Unknown
+}
+
+// GRPCCode returns the corresponding http status code from an error
+func GRPCCode(err error) codes.Code {
+	e, ok := err.(Error)
+	if ok {
+		return e.Type().GRPCCode()
+	}
+
+	return grpc.Code(err)
+}

--- a/errors/grpc.go
+++ b/errors/grpc.go
@@ -47,6 +47,8 @@ func (t Type) GRPCCode() codes.Code {
 	return codes.Unknown
 }
 
+// GRPCCodeToType converts the gRPC error code to an error type or returns the
+// Unknown type if not possible.
 func GRPCCodeToType(code codes.Code) Type {
 	switch code {
 	case codes.InvalidArgument:

--- a/errors/grpc_test.go
+++ b/errors/grpc_test.go
@@ -16,7 +16,7 @@ func TestGRPC(t *testing.T) {
 	a := assertions.New(t)
 	d := &ErrDescriptor{
 		MessageFormat: "You do not have access to app with id {app_id}",
-		Code:          77,
+		Code:          code(77),
 		Type:          PermissionDenied,
 		registered:    true,
 	}
@@ -54,7 +54,7 @@ func TestFromUnspecifiedGRPC(t *testing.T) {
 	err := grpc.Errorf(codes.DeadlineExceeded, "This is an error")
 
 	got := FromGRPC(err)
-	a.So(got.Code(), assertions.ShouldEqual, 0)
+	a.So(got.Code(), assertions.ShouldEqual, NoCode)
 	a.So(got.Type(), assertions.ShouldEqual, Timeout)
 	a.So(got.Error(), assertions.ShouldEqual, "This is an error")
 	a.So(got.Attributes(), assertions.ShouldBeNil)

--- a/errors/grpc_test.go
+++ b/errors/grpc_test.go
@@ -7,10 +7,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/smartystreets/assertions"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-
-	"github.com/smartystreets/assertions"
 )
 
 func TestGRPC(t *testing.T) {

--- a/errors/grpc_test.go
+++ b/errors/grpc_test.go
@@ -1,3 +1,6 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
 package errors
 
 import (

--- a/errors/grpc_test.go
+++ b/errors/grpc_test.go
@@ -1,0 +1,59 @@
+package errors
+
+import (
+	"fmt"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+
+	"github.com/smartystreets/assertions"
+)
+
+func TestGRPC(t *testing.T) {
+	a := assertions.New(t)
+	d := &ErrDescriptor{
+		MessageFormat: "You do not have access to app with id {app_id}",
+		Code:          77,
+		Type:          PermissionDenied,
+		registered:    true,
+	}
+
+	attributes := Attributes{
+		"app_id": "foo",
+		"count":  42,
+	}
+
+	err := d.New(attributes)
+
+	code := GRPCCode(err)
+	a.So(code, assertions.ShouldEqual, codes.PermissionDenied)
+
+	// other errors should be unknown
+	other := fmt.Errorf("Foo")
+	code = GRPCCode(other)
+	a.So(code, assertions.ShouldEqual, codes.Unknown)
+
+	grpcErr := ToGRPC(err)
+
+	got := FromGRPC(grpcErr)
+	a.So(got.Code(), assertions.ShouldEqual, d.Code)
+	a.So(got.Type(), assertions.ShouldEqual, d.Type)
+	a.So(got.Error(), assertions.ShouldEqual, "You do not have access to app with id foo")
+
+	a.So(got.Attributes(), assertions.ShouldNotBeEmpty)
+	a.So(got.Attributes()["app_id"], assertions.ShouldResemble, attributes["app_id"])
+	a.So(got.Attributes()["count"], assertions.ShouldAlmostEqual, attributes["count"])
+}
+
+func TestFromUnspecifiedGRPC(t *testing.T) {
+	a := assertions.New(t)
+
+	err := grpc.Errorf(codes.DeadlineExceeded, "This is an error")
+
+	got := FromGRPC(err)
+	a.So(got.Code(), assertions.ShouldEqual, 0)
+	a.So(got.Type(), assertions.ShouldEqual, Timeout)
+	a.So(got.Error(), assertions.ShouldEqual, "This is an error")
+	a.So(got.Attributes(), assertions.ShouldBeNil)
+}

--- a/errors/http.go
+++ b/errors/http.go
@@ -1,6 +1,12 @@
 package errors
 
-import "net/http"
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// CodeHeader is the header where the error code will be stored
+const CodeHeader = "X-TTN-Error-Code"
 
 // HTTPStatusCode returns the corresponding http status code from an error type
 func (t Type) HTTPStatusCode() int {
@@ -8,35 +14,25 @@ func (t Type) HTTPStatusCode() int {
 	case InvalidArgument:
 	case OutOfRange:
 		return http.StatusBadRequest
-
 	case NotFound:
 		return http.StatusNotFound
-
 	case Conflict:
 	case AlreadyExists:
 		return http.StatusConflict
-
 	case Unauthorized:
 		return http.StatusUnauthorized
-
 	case PermissionDenied:
 		return http.StatusForbidden
-
 	case Timeout:
 		return http.StatusRequestTimeout
-
 	case NotImplemented:
 		return http.StatusNotImplemented
-
 	case TemporarilyUnavailable:
 		return http.StatusBadGateway
-
 	case PermanentlyUnavailable:
 		return http.StatusGone
-
 	case ResourceExhausted:
 		return http.StatusTooManyRequests
-
 	case Unknown:
 	case Internal:
 	case Canceled:
@@ -55,4 +51,74 @@ func HTTPStatusCode(err error) int {
 	}
 
 	return http.StatusInternalServerError
+}
+
+// HTTPStatusToType infers the error Type from a HTTP Status code
+func HTTPStatusToType(status int) Type {
+	switch status {
+	case http.StatusBadRequest:
+		return InvalidArgument
+	case http.StatusNotFound:
+		return NotFound
+	case http.StatusConflict:
+		return Conflict
+	case http.StatusUnauthorized:
+		return Unauthorized
+	case http.StatusForbidden:
+		return PermissionDenied
+	case http.StatusRequestTimeout:
+		return Timeout
+	case http.StatusNotImplemented:
+		return NotImplemented
+	case http.StatusBadGateway:
+	case http.StatusServiceUnavailable:
+		return TemporarilyUnavailable
+	case http.StatusGone:
+		return PermanentlyUnavailable
+	case http.StatusTooManyRequests:
+		return ResourceExhausted
+	case http.StatusInternalServerError:
+		return Unknown
+	}
+	return Unknown
+}
+
+// FromHTTP parses the http.Response and returns the corresponding
+// If the response is not an error (eg. 200 OK), it returns nil
+func FromHTTP(resp *http.Response) Error {
+	if resp.StatusCode < 399 {
+		return nil
+	}
+
+	out := new(impl)
+
+	// try to decode the error
+	defer resp.Body.Close()
+	err := json.NewDecoder(resp.Body).Decode(out)
+	if err == nil {
+		return out
+	}
+
+	// fall back
+	out.Icode = parseCode(resp.Header.Get(CodeHeader))
+	out.Ityp = HTTPStatusToType(resp.StatusCode)
+	out.Imessage = out.Ityp.String()
+
+	return out
+}
+
+// ToHTTP writes the error to the http response
+func ToHTTP(in error, w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	if err, ok := in.(Error); ok {
+		w.Header().Set(CodeHeader, err.Code().String())
+		w.WriteHeader(err.Type().HTTPStatusCode())
+		return json.NewEncoder(w).Encode(toImpl(err))
+	}
+
+	w.WriteHeader(http.StatusInternalServerError)
+	return json.NewEncoder(w).Encode(&impl{
+		Imessage: in.Error(),
+		Ityp:     Unknown,
+	})
 }

--- a/errors/http.go
+++ b/errors/http.go
@@ -92,14 +92,14 @@ func FromHTTP(resp *http.Response) Error {
 
 	out := new(impl)
 
-	// try to decode the error
+	// try to decode the error from the body
 	defer resp.Body.Close()
 	err := json.NewDecoder(resp.Body).Decode(out)
 	if err == nil {
 		return out
 	}
 
-	// fall back
+	// fallback
 	out.Icode = parseCode(resp.Header.Get(CodeHeader))
 	out.Ityp = HTTPStatusToType(resp.StatusCode)
 	out.Imessage = out.Ityp.String()

--- a/errors/http.go
+++ b/errors/http.go
@@ -14,12 +14,16 @@ const CodeHeader = "X-TTN-Error-Code"
 // HTTPStatusCode returns the corresponding http status code from an error type
 func (t Type) HTTPStatusCode() int {
 	switch t {
+	case Canceled:
+		return http.StatusRequestTimeout
 	case InvalidArgument:
+		return http.StatusBadRequest
 	case OutOfRange:
 		return http.StatusBadRequest
 	case NotFound:
 		return http.StatusNotFound
 	case Conflict:
+		return http.StatusConflict
 	case AlreadyExists:
 		return http.StatusConflict
 	case Unauthorized:
@@ -35,10 +39,10 @@ func (t Type) HTTPStatusCode() int {
 	case PermanentlyUnavailable:
 		return http.StatusGone
 	case ResourceExhausted:
-		return http.StatusTooManyRequests
-	case Unknown:
+		return http.StatusForbidden
 	case Internal:
-	case Canceled:
+		return http.StatusInternalServerError
+	case Unknown:
 		return http.StatusInternalServerError
 	}
 

--- a/errors/http.go
+++ b/errors/http.go
@@ -34,8 +34,12 @@ func (t Type) HTTPStatusCode() int {
 	case PermanentlyUnavailable:
 		return http.StatusGone
 
+	case ResourceExhausted:
+		return http.StatusTooManyRequests
+
 	case Unknown:
 	case Internal:
+	case Canceled:
 		return http.StatusInternalServerError
 	}
 

--- a/errors/http.go
+++ b/errors/http.go
@@ -1,3 +1,6 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
 package errors
 
 import (

--- a/errors/http.go
+++ b/errors/http.go
@@ -49,8 +49,7 @@ func (t Type) HTTPStatusCode() int {
 	return http.StatusInternalServerError
 }
 
-// HTTPStatusCode returns the HTTP status code for the given error
-// or 500 if it doesn't know
+// HTTPStatusCode returns the HTTP status code for the given error or 500 if it doesn't know
 func HTTPStatusCode(err error) int {
 	e, ok := err.(Error)
 	if ok {
@@ -125,7 +124,7 @@ func ToHTTP(in error, w http.ResponseWriter) error {
 	if err, ok := in.(Error); ok {
 		w.Header().Set(CodeHeader, err.Code().String())
 		w.WriteHeader(err.Type().HTTPStatusCode())
-		return json.NewEncoder(w).Encode(toJson(err))
+		return json.NewEncoder(w).Encode(toJSON(err))
 	}
 
 	w.WriteHeader(http.StatusInternalServerError)

--- a/errors/http.go
+++ b/errors/http.go
@@ -1,0 +1,54 @@
+package errors
+
+import "net/http"
+
+// HTTPStatusCode returns the corresponding http status code from an error type
+func (t Type) HTTPStatusCode() int {
+	switch t {
+	case InvalidArgument:
+	case OutOfRange:
+		return http.StatusBadRequest
+
+	case NotFound:
+		return http.StatusNotFound
+
+	case Conflict:
+	case AlreadyExists:
+		return http.StatusConflict
+
+	case Unauthorized:
+		return http.StatusUnauthorized
+
+	case PermissionDenied:
+		return http.StatusForbidden
+
+	case Timeout:
+		return http.StatusRequestTimeout
+
+	case NotImplemented:
+		return http.StatusNotImplemented
+
+	case TemporarilyUnavailable:
+		return http.StatusBadGateway
+
+	case PermanentlyUnavailable:
+		return http.StatusGone
+
+	case Unknown:
+	case Internal:
+		return http.StatusInternalServerError
+	}
+
+	return http.StatusInternalServerError
+}
+
+// HTTPStatusCode returns the HTTP status code for the given error
+// or 500 if it doesn't know
+func HTTPStatusCode(err error) int {
+	e, ok := err.(Error)
+	if ok {
+		return e.Type().HTTPStatusCode()
+	}
+
+	return http.StatusInternalServerError
+}

--- a/errors/http_test.go
+++ b/errors/http_test.go
@@ -1,0 +1,58 @@
+package errors
+
+import (
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/smartystreets/assertions"
+)
+
+func TestHTTP(t *testing.T) {
+	a := assertions.New(t)
+
+	d := &ErrDescriptor{
+		MessageFormat: "You do not have access to app with id {app_id}",
+		Code:          77,
+		Type:          PermissionDenied,
+		registered:    true,
+	}
+
+	attributes := Attributes{
+		"app_id": "foo",
+		"count":  42,
+	}
+
+	err := d.New(attributes)
+
+	w := httptest.NewRecorder()
+	e := ToHTTP(err, w)
+	a.So(e, assertions.ShouldBeNil)
+
+	resp := w.Result()
+
+	got := FromHTTP(resp)
+	a.So(got.Code(), assertions.ShouldEqual, err.Code())
+	a.So(got.Type(), assertions.ShouldEqual, err.Type())
+	a.So(got.Error(), assertions.ShouldEqual, err.Error())
+	a.So(got.Attributes()["app_id"], assertions.ShouldResemble, attributes["app_id"])
+	a.So(got.Attributes()["count"], assertions.ShouldAlmostEqual, attributes["count"])
+}
+
+func TestToUnspecifiedHTTP(t *testing.T) {
+	a := assertions.New(t)
+
+	err := errors.New("A random error")
+
+	w := httptest.NewRecorder()
+	e := ToHTTP(err, w)
+	a.So(e, assertions.ShouldBeNil)
+
+	resp := w.Result()
+
+	got := FromHTTP(resp)
+	a.So(got.Code(), assertions.ShouldEqual, Code(0))
+	a.So(got.Type(), assertions.ShouldEqual, Unknown)
+	a.So(got.Error(), assertions.ShouldEqual, err.Error())
+	a.So(got.Attributes(), assertions.ShouldBeNil)
+}

--- a/errors/http_test.go
+++ b/errors/http_test.go
@@ -11,12 +11,15 @@ import (
 	"github.com/smartystreets/assertions"
 )
 
+// code creates Codes for testing
+var code = Range(10000, 11000)
+
 func TestHTTP(t *testing.T) {
 	a := assertions.New(t)
 
 	d := &ErrDescriptor{
 		MessageFormat: "You do not have access to app with id {app_id}",
-		Code:          77,
+		Code:          code(77),
 		Type:          PermissionDenied,
 		registered:    true,
 	}
@@ -54,7 +57,7 @@ func TestToUnspecifiedHTTP(t *testing.T) {
 	resp := w.Result()
 
 	got := FromHTTP(resp)
-	a.So(got.Code(), assertions.ShouldEqual, Code(0))
+	a.So(got.Code(), assertions.ShouldEqual, NoCode)
 	a.So(got.Type(), assertions.ShouldEqual, Unknown)
 	a.So(got.Error(), assertions.ShouldEqual, err.Error())
 	a.So(got.Attributes(), assertions.ShouldBeNil)

--- a/errors/http_test.go
+++ b/errors/http_test.go
@@ -1,3 +1,6 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
 package errors
 
 import (

--- a/errors/impl.go
+++ b/errors/impl.go
@@ -1,3 +1,6 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
 package errors
 
 // impl implements Error

--- a/errors/impl.go
+++ b/errors/impl.go
@@ -5,30 +5,30 @@ package errors
 
 // impl implements Error
 type impl struct {
-	Imessage    string     `json:"error"`
-	Icode       Code       `json:"error_code,omitempty"`
-	Ityp        Type       `json:"error_type,omitempty"`
-	Iattributes Attributes `json:"attributes,omitempty"`
+	message    string     `json:"error"`
+	code       Code       `json:"error_code,omitempty"`
+	typ        Type       `json:"error_type,omitempty"`
+	attributes Attributes `json:"attributes,omitempty"`
 }
 
 // Error returns the formatted error message
 func (i *impl) Error() string {
-	return i.Imessage
+	return i.message
 }
 
 // Code returns the error code
 func (i *impl) Code() Code {
-	return i.Icode
+	return i.code
 }
 
 // Type returns the error type
 func (i *impl) Type() Type {
-	return i.Ityp
+	return i.typ
 }
 
 // Attributes returns the error attributes
 func (i *impl) Attributes() Attributes {
-	return i.Iattributes
+	return i.attributes
 }
 
 // toImpl creates an equivalent impl for any Error
@@ -38,9 +38,9 @@ func toImpl(err Error) *impl {
 	}
 
 	return &impl{
-		Imessage:    err.Error(),
-		Icode:       err.Code(),
-		Ityp:        err.Type(),
-		Iattributes: err.Attributes(),
+		message:    err.Error(),
+		code:       err.Code(),
+		typ:        err.Type(),
+		attributes: err.Attributes(),
 	}
 }

--- a/errors/impl.go
+++ b/errors/impl.go
@@ -2,28 +2,42 @@ package errors
 
 // impl implements Error
 type impl struct {
-	message    string
-	code       Code
-	typ        Type
-	attributes Attributes
+	Imessage    string     `json:"error"`
+	Icode       Code       `json:"error_code,omitempty"`
+	Ityp        Type       `json:"error_type,omitempty"`
+	Iattributes Attributes `json:"attributes,omitempty"`
 }
 
 // Error returns the formatted error message
 func (i *impl) Error() string {
-	return i.message
+	return i.Imessage
 }
 
 // Code returns the error code
 func (i *impl) Code() Code {
-	return i.code
+	return i.Icode
 }
 
 // Type returns the error type
 func (i *impl) Type() Type {
-	return i.typ
+	return i.Ityp
 }
 
 // Attributes returns the error attributes
 func (i *impl) Attributes() Attributes {
-	return i.attributes
+	return i.Iattributes
+}
+
+// toImpl creates an equivalent impl for any Error
+func toImpl(err Error) *impl {
+	if i, ok := err.(*impl); ok {
+		return i
+	}
+
+	return &impl{
+		Imessage:    err.Error(),
+		Icode:       err.Code(),
+		Ityp:        err.Type(),
+		Iattributes: err.Attributes(),
+	}
 }

--- a/errors/impl.go
+++ b/errors/impl.go
@@ -1,0 +1,29 @@
+package errors
+
+// impl implements Error
+type impl struct {
+	message    string
+	code       Code
+	typ        Type
+	attributes Attributes
+}
+
+// Error returns the formatted error message
+func (i *impl) Error() string {
+	return i.message
+}
+
+// Code returns the error code
+func (i *impl) Code() Code {
+	return i.code
+}
+
+// Type returns the error type
+func (i *impl) Type() Type {
+	return i.typ
+}
+
+// Attributes returns the error attributes
+func (i *impl) Attributes() Attributes {
+	return i.attributes
+}

--- a/errors/json.go
+++ b/errors/json.go
@@ -10,7 +10,7 @@ type jsonError struct {
 	Attributes Attributes `json:"attributes,omitempty"`
 }
 
-func toJson(err Error) *jsonError {
+func toJSON(err Error) *jsonError {
 	return &jsonError{
 		Message:    err.Error(),
 		Code:       err.Code(),

--- a/errors/json.go
+++ b/errors/json.go
@@ -1,0 +1,20 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package errors
+
+type jsonError struct {
+	Message    string     `json:"error"`
+	Code       Code       `json:"error_code,omitempty"`
+	Type       Type       `json:"error_type,omitempty"`
+	Attributes Attributes `json:"attributes,omitempty"`
+}
+
+func toJson(err Error) *jsonError {
+	return &jsonError{
+		Message:    err.Error(),
+		Code:       err.Code(),
+		Type:       err.Type(),
+		Attributes: err.Attributes(),
+	}
+}

--- a/errors/registry.go
+++ b/errors/registry.go
@@ -41,8 +41,10 @@ var reg = &registry{
 }
 
 // Register registers a new error descriptor
-func Register(descriptor *ErrDescriptor) {
-	reg.Register(descriptor)
+func Register(descriptors ...*ErrDescriptor) {
+	for _, descriptor := range descriptors {
+		reg.Register(descriptor)
+	}
 }
 
 // Get returns an error descriptor based on an error code

--- a/errors/registry.go
+++ b/errors/registry.go
@@ -52,29 +52,28 @@ func Get(code Code) *ErrDescriptor {
 	return reg.Get(code)
 }
 
-// Descriptor returns the error descriptor from any error
-func Descriptor(err error) (desc *ErrDescriptor) {
-	var code Code
-
-	// let's hope it's an Error
-	e, ok := err.(Error)
-	if ok {
-		code = e.Code()
-		desc = Get(code)
+// From lifts an error to be and Error
+func From(in error) Error {
+	if err, ok := in.(Error); ok {
+		return err
 	}
 
-	// TODO: try to get from http or grpc errors
+	return FromGRPC(in)
+}
 
-	// if the descriptor was found, return it
-	if desc != nil {
-		return desc
+// Descriptor returns the error descriptor from any error
+func Descriptor(in error) (desc *ErrDescriptor) {
+	err := From(in)
+	descriptor := Get(err.Code())
+	if descriptor != nil {
+		return descriptor
 	}
 
 	// return a new error descriptor with sane defaults
 	return &ErrDescriptor{
 		MessageFormat: err.Error(),
-		Type:          Unknown,
-		Code:          code,
+		Type:          err.Type(),
+		Code:          err.Code(),
 	}
 }
 

--- a/errors/registry.go
+++ b/errors/registry.go
@@ -40,6 +40,9 @@ func (r *registry) Get(code Code) *ErrDescriptor {
 
 // GetAll returns all registered error descriptors
 func (r *registry) GetAll() []*ErrDescriptor {
+	r.RLock()
+	defer r.RUnlock()
+
 	res := make([]*ErrDescriptor, 0, len(r.byCode))
 	for _, d := range r.byCode {
 		res = append(res, d)

--- a/errors/registry.go
+++ b/errors/registry.go
@@ -38,6 +38,15 @@ func (r *registry) Get(code Code) *ErrDescriptor {
 	return r.byCode[code]
 }
 
+// GetAll returns all registered error descriptors
+func (r *registry) GetAll() []*ErrDescriptor {
+	res := make([]*ErrDescriptor, 0, len(r.byCode))
+	for _, d := range r.byCode {
+		res = append(res, d)
+	}
+	return res
+}
+
 // reg is a global registry to be shared by packages
 var reg = &registry{
 	byCode: make(map[Code]*ErrDescriptor),
@@ -106,4 +115,9 @@ func GetAttributes(err error) Attributes {
 	}
 
 	return Attributes{}
+}
+
+// GetAll returns all registered error descriptors
+func GetAll() []*ErrDescriptor {
+	return reg.GetAll()
 }

--- a/errors/registry.go
+++ b/errors/registry.go
@@ -1,0 +1,105 @@
+package errors
+
+import (
+	"fmt"
+	"sync"
+)
+
+// registry represents an error type registry
+type registry struct {
+	sync.RWMutex
+	byCode map[Code]*ErrDescriptor
+}
+
+// Register registers a new error type
+func (r *registry) Register(err *ErrDescriptor) {
+	r.Lock()
+	defer r.Unlock()
+
+	if err.Code == 0 {
+		panic(fmt.Errorf("No code defined in error descriptor (message: `%s`)", err.MessageFormat))
+	}
+
+	if r.byCode[err.Code] != nil {
+		panic(fmt.Errorf("errors: Duplicate error code %v registered", err.Code))
+	}
+
+	err.registered = true
+	r.byCode[err.Code] = err
+}
+
+// Get returns the descriptor if it exists or nil otherwise
+func (r *registry) Get(code Code) *ErrDescriptor {
+	r.RLock()
+	defer r.RUnlock()
+	return r.byCode[code]
+}
+
+// reg is a global registry to be shared by packages
+var reg = &registry{
+	byCode: make(map[Code]*ErrDescriptor),
+}
+
+// Register registers a new error descriptor
+func Register(descriptor *ErrDescriptor) {
+	reg.Register(descriptor)
+}
+
+// Get returns an error descriptor based on an error code
+func Get(code Code) *ErrDescriptor {
+	return reg.Get(code)
+}
+
+// Descriptor returns the error descriptor from any error
+func Descriptor(err error) (desc *ErrDescriptor) {
+	var code Code
+
+	// let's hope it's an Error
+	e, ok := err.(Error)
+	if ok {
+		code = e.Code()
+		desc = Get(code)
+	}
+
+	// TODO: try to get from http or grpc errors
+
+	// if the descriptor was found, return it
+	if desc != nil {
+		return desc
+	}
+
+	// return a new error descriptor with sane defaults
+	return &ErrDescriptor{
+		MessageFormat: err.Error(),
+		Type:          Unknown,
+		Code:          code,
+	}
+}
+
+// GetCode infers the error code from the error
+func GetCode(err error) Code {
+	return Descriptor(err).Code
+}
+
+// GetMessageFormat infers the message format from the error
+// or falls back to the error message
+func GetMessageFormat(err error) string {
+	return Descriptor(err).MessageFormat
+}
+
+// GetType infers the error type from the error
+// or falls back to Unknown
+func GetType(err error) Type {
+	return Descriptor(err).Type
+}
+
+// GetAttributes returns the error attributes or falls back
+// to empty attributes
+func GetAttributes(err error) Attributes {
+	e, ok := err.(Error)
+	if ok {
+		return e.Attributes()
+	}
+
+	return Attributes{}
+}

--- a/errors/registry.go
+++ b/errors/registry.go
@@ -1,3 +1,6 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
 package errors
 
 import (

--- a/errors/registry.go
+++ b/errors/registry.go
@@ -19,7 +19,7 @@ func (r *registry) Register(err *ErrDescriptor) {
 	r.Lock()
 	defer r.Unlock()
 
-	if err.Code == 0 {
+	if err.Code == NoCode {
 		panic(fmt.Errorf("No code defined in error descriptor (message: `%s`)", err.MessageFormat))
 	}
 

--- a/errors/type.go
+++ b/errors/type.go
@@ -55,29 +55,51 @@ const (
 	// PermanentlyUnavailable is the type of errors that result from an action
 	// that has been deprecated and is no longer available
 	PermanentlyUnavailable
-)
 
-// string representations of the Types
-// keep up to date with the iota
-var str = []string{
-	"Unknown",
-	"Internal",
-	"Invalid argument",
-	"Out of range",
-	"Not found",
-	"Conflict",
-	"Already exists",
-	"Unauthorized",
-	"Permission denied",
-	"Timeout",
-	"Not implemented",
-	"Temporarily unavailable",
-	"Permanently unavailable",
-}
+	// Canceled indicates the operation was canceled (typically by the caller)
+	Canceled
+
+	// ResourceExhausted indicates some resource has been exhausted, perhaps
+	// a per-user quota, or perhaps the entire file system is out of space.
+	ResourceExhausted
+)
 
 // String implements stringer
 func (t Type) String() string {
-	return str[t]
+	switch t {
+	case Unknown:
+		return "Unknown"
+	case Internal:
+		return "Internal"
+	case InvalidArgument:
+		return "Invalid argument"
+	case OutOfRange:
+		return "Out of range"
+	case NotFound:
+		return "Not found"
+	case Conflict:
+		return "Conflict"
+	case AlreadyExists:
+		return "Already exists"
+	case Unauthorized:
+		return "Unauthorized"
+	case PermissionDenied:
+		return "Permission denied"
+	case Timeout:
+		return "Timeout"
+	case NotImplemented:
+		return "Not implemented"
+	case TemporarilyUnavailable:
+		return "Temporarily unavailable"
+	case PermanentlyUnavailable:
+		return "Permanently unavailable"
+	case Canceled:
+		return "Canceled"
+	case ResourceExhausted:
+		return "Resource exhausted"
+	default:
+		return "Unknown"
+	}
 }
 
 // MarshalText implements TextMarsheler
@@ -87,13 +109,50 @@ func (t Type) MarshalText() ([]byte, error) {
 
 // UnmarshalText implements TextUnmarsheler
 func (t *Type) UnmarshalText(text []byte) error {
-	enum := strings.ToLower(string(text))
-	for i, typ := range str {
-		if enum == strings.ToLower(typ) {
-			*t = Type(i)
-			return nil
-		}
+	e, err := fromString(string(text))
+	if err != nil {
+		return err
 	}
 
-	return fmt.Errorf("Invalid event type")
+	*t = e
+
+	return nil
+}
+
+func fromString(str string) (Type, error) {
+	enum := strings.ToLower(str)
+	switch enum {
+	case "unknown":
+		return Unknown, nil
+	case "internal":
+		return Internal, nil
+	case "invalid argument":
+		return InvalidArgument, nil
+	case "out of range":
+		return OutOfRange, nil
+	case "not found":
+		return NotFound, nil
+	case "conflict":
+		return Conflict, nil
+	case "already exists":
+		return AlreadyExists, nil
+	case "unauthorized":
+		return Unauthorized, nil
+	case "permission denied":
+		return PermissionDenied, nil
+	case "timeout":
+		return Timeout, nil
+	case "not implemented":
+		return NotImplemented, nil
+	case "temporarily unavailable":
+		return TemporarilyUnavailable, nil
+	case "permanently unavailable":
+		return PermanentlyUnavailable, nil
+	case "canceled":
+		return Canceled, nil
+	case "resource exhausted":
+		return ResourceExhausted, nil
+	default:
+		return Unknown, fmt.Errorf("Invalid event type")
+	}
 }

--- a/errors/type.go
+++ b/errors/type.go
@@ -122,6 +122,8 @@ func (t *Type) UnmarshalText(text []byte) error {
 	return nil
 }
 
+// fromString parses a string into an error type. If the type is invalid, the
+// Unknown type will be returned as well as an error.
 func fromString(str string) (Type, error) {
 	enum := strings.ToLower(str)
 	switch enum {
@@ -156,6 +158,6 @@ func fromString(str string) (Type, error) {
 	case "resource exhausted":
 		return ResourceExhausted, nil
 	default:
-		return Unknown, fmt.Errorf("Invalid event type")
+		return Unknown, fmt.Errorf("Invalid error type")
 	}
 }

--- a/errors/type.go
+++ b/errors/type.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 )
 
+// Type is the type of an error which, much like gRPC Codes or HTTP Status Codes,
+// denotes what category an error belongs to and how to handle it.
 type Type uint8
 
 const (

--- a/errors/type.go
+++ b/errors/type.go
@@ -1,0 +1,53 @@
+package errors
+
+type Type uint8
+
+const (
+	// Unknown is the type of unknown or unexpected errors
+	Unknown Type = iota
+
+	// Internal is the type of internal errors
+	Internal
+
+	// InvalidArgument is the type of errors that result from an invalid argument
+	// in a request
+	InvalidArgument
+
+	// OutOfRange is the type of errors that result from an out of range request
+	OutOfRange
+
+	// NotFound is the type of errors that result from an entity that is not found
+	// or not accessible
+	NotFound
+
+	// Conflict is the type of errors that result from a conflict
+	Conflict
+
+	// AlreadyExists is the type of errors that result from a conflict where the
+	// updated/created entity already exists
+	AlreadyExists
+
+	// Unauthorized is the type of errors where the request is unauthorized where
+	// it should be
+	Unauthorized
+
+	// PermissionDenied is the type of errors where the request was authorized but
+	// did not grant access to the requested entity
+	PermissionDenied
+
+	// Timeout is the type of errors that are a result of a process taking too
+	// long to complete
+	Timeout
+
+	// NotImplemented is the type of errors that result from a requested action
+	// that is not (yet) implemented
+	NotImplemented
+
+	// TemporarilyUnavailable is the type of errors that result from a service
+	// being temporarily unavailable (down)
+	TemporarilyUnavailable
+
+	// PermanentlyUnavailable is the type of errors that result from an action
+	// that has been deprecated and is no longer available
+	PermanentlyUnavailable
+)

--- a/errors/type.go
+++ b/errors/type.go
@@ -1,3 +1,6 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
 package errors
 
 import (

--- a/errors/type.go
+++ b/errors/type.go
@@ -1,5 +1,10 @@
 package errors
 
+import (
+	"fmt"
+	"strings"
+)
+
 type Type uint8
 
 const (
@@ -51,3 +56,44 @@ const (
 	// that has been deprecated and is no longer available
 	PermanentlyUnavailable
 )
+
+// string representations of the Types
+// keep up to date with the iota
+var str = []string{
+	"Unknown",
+	"Internal",
+	"Invalid argument",
+	"Out of range",
+	"Not found",
+	"Conflict",
+	"Already exists",
+	"Unauthorized",
+	"Permission denied",
+	"Timeout",
+	"Not implemented",
+	"Temporarily unavailable",
+	"Permanently unavailable",
+}
+
+// String implements stringer
+func (t Type) String() string {
+	return str[t]
+}
+
+// MarshalText implements TextMarsheler
+func (t Type) MarshalText() ([]byte, error) {
+	return []byte(t.String()), nil
+}
+
+// UnmarshalText implements TextUnmarsheler
+func (t *Type) UnmarshalText(text []byte) error {
+	enum := strings.ToLower(string(text))
+	for i, typ := range str {
+		if enum == strings.ToLower(typ) {
+			*t = Type(i)
+			return nil
+		}
+	}
+
+	return fmt.Errorf("Invalid event type")
+}

--- a/errors/type_test.go
+++ b/errors/type_test.go
@@ -1,3 +1,6 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
 package errors
 
 import (

--- a/errors/type_test.go
+++ b/errors/type_test.go
@@ -4,35 +4,60 @@
 package errors
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/smartystreets/assertions"
 )
 
+var types = map[string]Type{
+	"Unknown":                 Unknown,
+	"Internal":                Internal,
+	"Invalid argument":        InvalidArgument,
+	"Out of range":            OutOfRange,
+	"Not found":               NotFound,
+	"Conflict":                Conflict,
+	"Already exists":          AlreadyExists,
+	"Unauthorized":            Unauthorized,
+	"Permission denied":       PermissionDenied,
+	"Timeout":                 Timeout,
+	"Not implemented":         NotImplemented,
+	"Temporarily unavailable": TemporarilyUnavailable,
+	"Permanently unavailable": PermanentlyUnavailable,
+	"Canceled":                Canceled,
+	"Resource exhausted":      ResourceExhausted,
+}
+
 func TestTypeString(t *testing.T) {
 	a := assertions.New(t)
 
-	a.So(Unknown.String(), assertions.ShouldEqual, "Unknown")
-	a.So(Timeout.String(), assertions.ShouldEqual, "Timeout")
+	for str, typ := range types {
+		a.So(typ.String(), assertions.ShouldEqual, str)
+	}
 }
 
 func TestTypeMarshal(t *testing.T) {
 	a := assertions.New(t)
 
-	text, err := Unknown.MarshalText()
-	a.So(err, assertions.ShouldBeNil)
-	a.So(text, assertions.ShouldResemble, []byte("Unknown"))
+	for str, typ := range types {
+		text, err := typ.MarshalText()
+		a.So(err, assertions.ShouldBeNil)
+		a.So(text, assertions.ShouldResemble, []byte(str))
+	}
 }
 
 func TestTypeUnmarshal(t *testing.T) {
 	a := assertions.New(t)
 
-	var typ Type
-	err := typ.UnmarshalText([]byte("Temporarily unavailable"))
-	a.So(err, assertions.ShouldBeNil)
-	a.So(typ, assertions.ShouldEqual, TemporarilyUnavailable)
+	for str, typ := range types {
+		var res Type
+		err := res.UnmarshalText([]byte(str))
+		a.So(err, assertions.ShouldBeNil)
+		a.So(res, assertions.ShouldEqual, typ)
 
-	err = typ.UnmarshalText([]byte("temporarily unavailable"))
-	a.So(err, assertions.ShouldBeNil)
-	a.So(typ, assertions.ShouldEqual, TemporarilyUnavailable)
+		err = res.UnmarshalText([]byte(strings.ToLower(str)))
+		a.So(err, assertions.ShouldBeNil)
+		a.So(res, assertions.ShouldEqual, typ)
+	}
+
 }

--- a/errors/type_test.go
+++ b/errors/type_test.go
@@ -1,0 +1,35 @@
+package errors
+
+import (
+	"testing"
+
+	"github.com/smartystreets/assertions"
+)
+
+func TestTypeString(t *testing.T) {
+	a := assertions.New(t)
+
+	a.So(Unknown.String(), assertions.ShouldEqual, "Unknown")
+	a.So(Timeout.String(), assertions.ShouldEqual, "Timeout")
+}
+
+func TestTypeMarshal(t *testing.T) {
+	a := assertions.New(t)
+
+	text, err := Unknown.MarshalText()
+	a.So(err, assertions.ShouldBeNil)
+	a.So(text, assertions.ShouldResemble, []byte("Unknown"))
+}
+
+func TestTypeUnmarshal(t *testing.T) {
+	a := assertions.New(t)
+
+	var typ Type
+	err := typ.UnmarshalText([]byte("Temporarily unavailable"))
+	a.So(err, assertions.ShouldBeNil)
+	a.So(typ, assertions.ShouldEqual, TemporarilyUnavailable)
+
+	err = typ.UnmarshalText([]byte("temporarily unavailable"))
+	a.So(err, assertions.ShouldBeNil)
+	a.So(typ, assertions.ShouldEqual, TemporarilyUnavailable)
+}


### PR DESCRIPTION
This pull request adds errors that are portable across different protocols (http, gRPC, ...) and that are localizable to a certain degree.

Every component (service, ...) that can create errors should define the error types it has using a descriptor. This descriptor can be used to create new errors of this type, which implement the builtin error interface.

On top of that helpers are included to convert errors from error into a more rich interface Error which has type info about the error.

The error types are also registered into an error registry which can be used to find more info about the types (like the localizable error format etc)

See `errors/example_test.go` for an example.