### PR TITLE
Add prometheus log wrapper

### DIFF
--- a/log/prometheus/prometheus.go
+++ b/log/prometheus/prometheus.go
@@ -1,0 +1,90 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package prometheus
+
+import (
+	"github.com/TheThingsNetwork/go-utils/log"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var logCounter = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "ttn",
+		Subsystem: "log",
+		Name:      "messages_total",
+		Help:      "Total log messages.",
+	},
+	[]string{"level"},
+)
+
+func init() {
+	prometheus.MustRegister(logCounter)
+}
+
+type prom struct {
+	log.Interface
+}
+
+const (
+	debug = "debug"
+	info  = "info"
+	warn  = "warn"
+	err   = "error"
+	fatal = "fatal"
+)
+
+func (p prom) Debug(msg string) {
+	logCounter.WithLabelValues(debug).Inc()
+	p.Interface.Debug(msg)
+}
+func (p prom) Info(msg string) {
+	logCounter.WithLabelValues(info).Inc()
+	p.Interface.Info(msg)
+}
+func (p prom) Warn(msg string) {
+	logCounter.WithLabelValues(warn).Inc()
+	p.Interface.Warn(msg)
+}
+func (p prom) Error(msg string) {
+	logCounter.WithLabelValues(err).Inc()
+	p.Interface.Error(msg)
+}
+func (p prom) Fatal(msg string) {
+	logCounter.WithLabelValues(fatal).Inc()
+	p.Interface.Fatal(msg)
+}
+func (p prom) Debugf(msg string, v ...interface{}) {
+	logCounter.WithLabelValues(debug).Inc()
+	p.Interface.Debugf(msg, v)
+}
+func (p prom) Infof(msg string, v ...interface{}) {
+	logCounter.WithLabelValues(info).Inc()
+	p.Interface.Infof(msg, v)
+}
+func (p prom) Warnf(msg string, v ...interface{}) {
+	logCounter.WithLabelValues(warn).Inc()
+	p.Interface.Warnf(msg, v)
+}
+func (p prom) Errorf(msg string, v ...interface{}) {
+	logCounter.WithLabelValues(err).Inc()
+	p.Interface.Errorf(msg, v)
+}
+func (p prom) Fatalf(msg string, v ...interface{}) {
+	logCounter.WithLabelValues(fatal).Inc()
+	p.Interface.Fatalf(msg, v)
+}
+func (p prom) WithField(k string, v interface{}) log.Interface {
+	return prom{p.Interface.WithField(k, v)}
+}
+func (p prom) WithFields(f log.Fields) log.Interface {
+	return prom{p.Interface.WithFields(f)}
+}
+func (p prom) WithError(err error) log.Interface {
+	return prom{p.Interface.WithError(err)}
+}
+
+// Wrap wraps an existing logger, counting logs by level
+func Wrap(logger log.Interface) log.Interface {
+	return prom{logger}
+}

--- a/log/prometheus/prometheus_test.go
+++ b/log/prometheus/prometheus_test.go
@@ -1,0 +1,86 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package prometheus
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/TheThingsNetwork/go-utils/log"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	. "github.com/smartystreets/assertions"
+)
+
+// noopLogger just does nothing
+type noopLogger struct{}
+
+func (l noopLogger) Debug(msg string)                            {}
+func (l noopLogger) Info(msg string)                             {}
+func (l noopLogger) Warn(msg string)                             {}
+func (l noopLogger) Error(msg string)                            {}
+func (l noopLogger) Fatal(msg string)                            {}
+func (l noopLogger) Debugf(msg string, v ...interface{})         {}
+func (l noopLogger) Infof(msg string, v ...interface{})          {}
+func (l noopLogger) Warnf(msg string, v ...interface{})          {}
+func (l noopLogger) Errorf(msg string, v ...interface{})         {}
+func (l noopLogger) Fatalf(msg string, v ...interface{})         {}
+func (l noopLogger) WithField(string, interface{}) log.Interface { return l }
+func (l noopLogger) WithFields(log.Fields) log.Interface         { return l }
+func (l noopLogger) WithError(error) log.Interface               { return l }
+
+func TestPrometheus(t *testing.T) {
+	a := New(t)
+
+	wrapped := Wrap(&noopLogger{})
+
+	withFields := wrapped.
+		WithError(errors.New("a")).
+		WithField("foo", "bar").
+		WithFields(log.Fields{"bar": "baz"})
+
+	ch := make(chan prometheus.Metric, 10)
+
+	collect := func() []*dto.Metric {
+		logCounter.Collect(ch)
+		metrics := make([]*dto.Metric, 0, len(ch))
+		for i := len(ch); i > 0; i-- {
+			metric := <-ch
+			m := new(dto.Metric)
+			metric.Write(m)
+			metrics = append(metrics, m)
+		}
+		return metrics
+	}
+
+	withFields.Debug("foo")
+	withFields.Debugf("foo %d", 42)
+
+	metrics := collect()
+	a.So(metrics, ShouldHaveLength, 1)
+
+	withFields.Info("foo")
+	withFields.Infof("foo %d", 42)
+
+	metrics = collect()
+	a.So(metrics, ShouldHaveLength, 2)
+
+	withFields.Warn("foo")
+	withFields.Warnf("foo %d", 42)
+
+	metrics = collect()
+	a.So(metrics, ShouldHaveLength, 3)
+
+	withFields.Error("foo")
+	withFields.Errorf("foo %d", 42)
+
+	metrics = collect()
+	a.So(metrics, ShouldHaveLength, 4)
+
+	withFields.Fatal("foo")
+	withFields.Fatalf("foo %d", 42)
+
+	metrics = collect()
+	a.So(metrics, ShouldHaveLength, 5)
+}


### PR DESCRIPTION
This PR adds a log wrapper that counts log messages per level and exposes them through Prometheus