### PR TITLE
Use jsoniter instead of encoding/json in encoding

### DIFF
--- a/encoding/decode.go
+++ b/encoding/decode.go
@@ -5,7 +5,7 @@ package encoding
 
 import (
 	"encoding"
-	"encoding/json"
+	stdjson "encoding/json"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -69,7 +69,7 @@ func unmarshalToType(typ reflect.Type, value string) (val interface{}, err error
 			return val, nil
 		}
 	}
-	if um, ok := val.(json.Unmarshaler); ok {
+	if um, ok := val.(stdjson.Unmarshaler); ok {
 		if err = um.UnmarshalJSON([]byte(value)); err == nil {
 			return val, nil
 		}

--- a/encoding/doc.go
+++ b/encoding/doc.go
@@ -4,3 +4,7 @@
 // Package encoding is responsible for encoding and decoding of structs.
 // `squash` option assumes that field names are unique in structs, otherwise results are unpredictable
 package encoding
+
+import jsoniter "github.com/json-iterator/go"
+
+var json = jsoniter.ConfigCompatibleWithStandardLibrary

--- a/encoding/encode.go
+++ b/encoding/encode.go
@@ -5,7 +5,7 @@ package encoding
 
 import (
 	"encoding"
-	"encoding/json"
+	stdjson "encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
@@ -176,7 +176,7 @@ func ToStringStringMap(tagName string, input interface{}, properties ...string) 
 				vmap.Set(fieldName, string(txt))
 				continue
 			}
-			if m, ok := val.(json.Marshaler); ok {
+			if m, ok := val.(stdjson.Marshaler); ok {
 				txt, err := m.MarshalJSON()
 				if err != nil {
 					return nil, err

--- a/encoding/encoding_test.go
+++ b/encoding/encoding_test.go
@@ -4,7 +4,6 @@
 package encoding
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math"

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/gotnospirit/messageformat v0.0.0-20190719172517-c1d0bdacdea2
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.0
 	github.com/influxdata/influxdb v1.7.6
+	github.com/json-iterator/go v1.1.9
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/onsi/ginkgo v1.12.0 // indirect
 	github.com/onsi/gomega v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,7 @@ github.com/influxdata/influxdb v1.7.6/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOpr
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jpillora/backoff v0.0.0-20180909062703-3050d21c67d7/go.mod h1:2iMrUgbbvHEiQClaW2NsSzMyGHqN+rDFqY705q49KG0=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
+github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGns=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
@@ -107,8 +108,10 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0j
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This quickfix changes the JSON library used by the `encoding` package from the standard `encoding/json` to [jsoniter](https://jsoniter.com/migrate-from-go-std.html), which is supposed to be a drop-in replacement. This is a very important fix since both `networkserver` and `handler` use JSON heavily on the hot path.

#### Changes
<!-- What are the changes made in this pull request? -->

- Use `jsoniter` in `encoding`.

#### Testing

<!-- How did you verify that this change works? -->

Unit tests.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

![image](https://user-images.githubusercontent.com/36161392/89643707-099f2800-d8bf-11ea-8eab-1e56dcebd522.png)
`networkserver` before and after (7AM)

![image](https://user-images.githubusercontent.com/36161392/89643968-93e78c00-d8bf-11ea-8ed5-023af30db590.png)
`handler` before and after (7AM)

![image](https://user-images.githubusercontent.com/36161392/89643845-52ef7780-d8bf-11ea-8737-65103515f04f.png)
`handler` hot path before

![image](https://user-images.githubusercontent.com/36161392/89643926-7ca89e80-d8bf-11ea-9589-12fa7b8439c2.png)
`handler` hot path after

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
